### PR TITLE
Automatic setting via a cache didn't override a previous auto load from cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        neovim_version: ['nightly', 'v0.10.4', 'v0.11.0']
+        neovim_version: ['nightly', 'v0.10.4', 'v0.11.6']
     steps:
       - uses: actions/checkout@v4
 
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        neovim_version: ['nightly', 'v0.10.4', 'v0.11.0']
+        neovim_version: ['nightly', 'v0.10.4', 'v0.11.6']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Run test
+name: CI
 
 on:
   pull_request: ~
@@ -6,6 +6,18 @@ on:
     branches: main
 
 jobs:
+  lint:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: JohnnyMorganz/stylua-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
+          args: --check lua/
+
   tests:
     name: Run tests
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,31 @@ jobs:
           version: latest
           args: --check lua/
 
+  lua-check:
+    name: Lua diagnostics
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        neovim_version: ['nightly', 'v0.10.4', 'v0.11.0']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: ${{ matrix.neovim_version }}
+
+      - name: Install lua-language-server
+        run: |
+          LUA_LS_VERSION="3.13.6"
+          mkdir -p "$HOME/lua-language-server"
+          curl -fsSL "https://github.com/LuaLS/lua-language-server/releases/download/${LUA_LS_VERSION}/lua-language-server-${LUA_LS_VERSION}-linux-x64.tar.gz" \
+            | tar xz -C "$HOME/lua-language-server"
+          echo "$HOME/lua-language-server/bin" >> "$GITHUB_PATH"
+
+      - name: Run lua-language-server check
+        run: make lua-check
+
   tests:
     name: Run tests
     runs-on: ubuntu-latest

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,10 @@
+{
+  "runtime.version": "LuaJIT",
+  "diagnostics.globals": ["vim"],
+  "workspace.library": [
+    "$VIMRUNTIME/lua",
+    "${3rd}/luv/library",
+    "${3rd}/busted/library",
+    "${3rd}/luassert/library"
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test_deps format format-check
+.PHONY: test test_deps format format-check lua-check
 
 test_deps:
 ifeq (,$(wildcard test_deps/plenary.nvim))
@@ -13,3 +13,9 @@ format:
 
 format-check:
 	stylua --check lua/
+
+LUA_LS ?= lua-language-server
+
+lua-check:
+	VIMRUNTIME=$$(nvim --clean --headless -c 'echo $$VIMRUNTIME' -c 'qa' 2>&1) \
+	  $(LUA_LS) --check . --checklevel=Warning

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test_deps
+.PHONY: test test_deps format format-check
 
 test_deps:
 ifeq (,$(wildcard test_deps/plenary.nvim))
@@ -7,3 +7,9 @@ endif
 
 test: test_deps
 	nvim --headless --noplugin -u scripts/minimal_init.lua -c "PlenaryBustedDirectory tests {minimal_init='./scripts/minimal_init.lua'}"
+
+format:
+	stylua lua/
+
+format-check:
+	stylua --check lua/

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ https://github.com/user-attachments/assets/bddd568a-947a-49d2-a403-efae2787f60a
   {
     cache_dir = vim.fn.stdpath("cache") .. "/whichpy.nvim",
     update_path_env = false,  -- Whether to modify $PATH when switching interpreters.
+    set_env_on_startup = false,  -- Whether to select a previous env for pwd on startup.
     after_handle_select = nil,  -- Equivalent to venv-selector.nvim's on_venv_activate_callback()
     -- after_handle_select = function(selected) vim.print(selected) end,
     picker = {

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://github.com/user-attachments/assets/bddd568a-947a-49d2-a403-efae2787f60a
 - Support multiple Lsp servers. (Pylsp, Pyright, BasedPyright)
 - Support nvim-dap-python.
 - Switch between python interpreters without restart LSPs. (Except `WhichPy reset` on Pyright)
-- Support multiple pickers. (`builtin`, `fzf-lua`, `telescope`)
+- Support multiple pickers. (`builtin`, `fzf-lua`, `telescope`, `snacks`)
 - Automatically select the previously chosen interpreter based on the directory.
 - Search on common directories, currently support:
   - workspace (`lsp.WorkspaceFolder` or `vim.fs.root` or `vim.fn.getcwd`)
@@ -40,6 +40,7 @@ https://github.com/user-attachments/assets/bddd568a-947a-49d2-a403-efae2787f60a
     -- optional for picker support
     -- "ibhagwan/fzf-lua",
     -- "nvim-telescope/telescope.nvim",
+    -- "folke/snacks.nvim",
   }
   opts = {},
 }
@@ -57,7 +58,7 @@ https://github.com/user-attachments/assets/bddd568a-947a-49d2-a403-efae2787f60a
     after_handle_select = nil,  -- Equivalent to venv-selector.nvim's on_venv_activate_callback()
     -- after_handle_select = function(selected) vim.print(selected) end,
     picker = {
-      name = "builtin",  -- must be one of ("builtin", "fzf-lua", "telescope")
+      name = "builtin",  -- must be one of ("builtin", "fzf-lua", "telescope", "snacks")
       -- You can customize the picker as follows. For available options, refer to the respective documentation.
       -- ["fzf-lua"] = {
       --   prompt="fzf-lua",
@@ -67,6 +68,9 @@ https://github.com/user-attachments/assets/bddd568a-947a-49d2-a403-efae2787f60a
       -- },
       -- builtin = {
       --   prompt="vim.ui.select",
+      -- },
+      -- snacks = {
+      --   prompt="Select Python Interpreter",
       -- },
     },
     locator = {

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ https://github.com/user-attachments/assets/bddd568a-947a-49d2-a403-efae2787f60a
   {
     cache_dir = vim.fn.stdpath("cache") .. "/whichpy.nvim",
     update_path_env = false,  -- Whether to modify $PATH when switching interpreters.
-    set_env_on_startup = false,  -- Whether to select a previous env for pwd on startup.
     after_handle_select = nil,  -- Equivalent to venv-selector.nvim's on_venv_activate_callback()
     -- after_handle_select = function(selected) vim.print(selected) end,
     picker = {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # whichpy.nvim
 
-Yet another python interpreter selector plugin for neovim. Make LSPs (pyright, pylsp, basedpyright) and DAP work with specific python.
+Yet another python interpreter selector plugin for neovim. Make LSPs (pyright, pylsp, basedpyright, ty) and DAP work with specific python.
 
 
 https://github.com/user-attachments/assets/bddd568a-947a-49d2-a403-efae2787f60a
@@ -8,9 +8,9 @@ https://github.com/user-attachments/assets/bddd568a-947a-49d2-a403-efae2787f60a
 
 ## Features
 
-- Support multiple Lsp servers. (Pylsp, Pyright, BasedPyright)
+- Support multiple Lsp servers. (Pylsp, Pyright, BasedPyright, ty)
 - Support nvim-dap-python.
-- Switch between python interpreters without restart LSPs. (Except `WhichPy reset` on Pyright)
+- Switch between python interpreters without restart LSPs. (Except `WhichPy reset` on Pyright and ty)
 - Support multiple pickers. (`builtin`, `fzf-lua`, `telescope`, `snacks`)
 - Automatically select the previously chosen interpreter based on the directory.
 - Search on common directories, currently support:
@@ -128,6 +128,7 @@ https://github.com/user-attachments/assets/bddd568a-947a-49d2-a403-efae2787f60a
       pylsp = require("whichpy.lsp.handlers.pylsp").new(),
       pyright = require("whichpy.lsp.handlers.pyright").new(),
       basedpyright = require("whichpy.lsp.handlers.pyright").new(),
+      ty = require("whichpy.lsp.handlers.ty").new(),
     },
   }
   ```

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ https://github.com/user-attachments/assets/bddd568a-947a-49d2-a403-efae2787f60a
   {
     cache_dir = vim.fn.stdpath("cache") .. "/whichpy.nvim",
     update_path_env = false,  -- Whether to modify $PATH when switching interpreters.
+    set_env_on_startup = false,  -- Whether to select a previous env for pwd on startup.
     after_handle_select = nil,  -- Equivalent to venv-selector.nvim's on_venv_activate_callback()
     -- after_handle_select = function(selected) vim.print(selected) end,
     picker = {

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ https://github.com/user-attachments/assets/bddd568a-947a-49d2-a403-efae2787f60a
   {
     cache_dir = vim.fn.stdpath("cache") .. "/whichpy.nvim",
     update_path_env = false,  -- Whether to modify $PATH when switching interpreters.
-    set_env_on_startup = false,  -- Whether to select a previous env for pwd on startup.
     after_handle_select = nil,  -- Equivalent to venv-selector.nvim's on_venv_activate_callback()
     -- after_handle_select = function(selected) vim.print(selected) end,
     picker = {

--- a/lua/whichpy/cache.lua
+++ b/lua/whichpy/cache.lua
@@ -1,0 +1,49 @@
+local util = require("whichpy.util")
+
+local M = {}
+
+---@param cache_dir string
+---@return string
+local function cache_filename(cache_dir)
+  local filename = vim.fn.getcwd():gsub("[\\/:]+", "%%")
+  return vim.fs.joinpath(cache_dir, filename)
+end
+
+---@param cache_dir string
+---@param interpreter_path string
+---@param locator_name string
+function M.save(cache_dir, interpreter_path, locator_name)
+  vim.fn.mkdir(cache_dir, "p")
+  local f, err = io.open(cache_filename(cache_dir), "wb")
+  if f then
+    f:write(interpreter_path .. "\n" .. locator_name)
+    f:close()
+  else
+    util.notify("Failed to write cache: " .. err, { level = vim.log.levels.WARN })
+  end
+end
+
+---@param cache_dir string
+---@return string? path
+---@return string? locator_name
+function M.load(cache_dir)
+  local f = io.open(cache_filename(cache_dir), "r")
+  if not f then
+    return nil, nil
+  end
+  local lines = {}
+  local line = f:read()
+  while line do
+    table.insert(lines, line)
+    line = f:read()
+  end
+  f:close()
+  return lines[1], lines[2]
+end
+
+---@param cache_dir string
+function M.remove(cache_dir)
+  os.remove(cache_filename(cache_dir))
+end
+
+return M

--- a/lua/whichpy/config.lua
+++ b/lua/whichpy/config.lua
@@ -4,6 +4,7 @@
 ---@field lsp? table<string,WhichPy.Lsp.Handler>
 ---@field picker? WhichPy.Config.Picker
 ---@field update_path_env? boolean
+---@field set_env_on_startup? boolean
 ---@field after_handle_select? fun(selected: WhichPy.InterpreterInfo)
 
 ---@class (exact) WhichPy.Config.Locator

--- a/lua/whichpy/config.lua
+++ b/lua/whichpy/config.lua
@@ -26,10 +26,11 @@
 ---@alias WhichPy.Config.Locator.Uv WhichPy.Locator.Opts|WhichPy.Locator.Uv.Opts
 
 ---@class WhichPy.Config.Picker
----@field name? "builtin"|"fzf-lua"|"telescope"
+---@field name? "builtin"|"fzf-lua"|"telescope"|"snacks"
 ---@field builtin? table
----@field fzf-lua? table
+---@field ["fzf-lua"]? table
 ---@field telescope? table
+---@field snacks? table
 
 ---@type WhichPy.Config
 local _default_config = {

--- a/lua/whichpy/config.lua
+++ b/lua/whichpy/config.lua
@@ -4,7 +4,6 @@
 ---@field lsp? table<string,WhichPy.Lsp.Handler>
 ---@field picker? WhichPy.Config.Picker
 ---@field update_path_env? boolean
----@field set_env_on_startup? boolean
 ---@field after_handle_select? fun(selected: WhichPy.InterpreterInfo)
 
 ---@class (exact) WhichPy.Config.Locator

--- a/lua/whichpy/config.lua
+++ b/lua/whichpy/config.lua
@@ -50,6 +50,7 @@ local _default_config = {
     pylsp = require("whichpy.lsp.handlers.pylsp").new(),
     pyright = require("whichpy.lsp.handlers.pyright").new(),
     basedpyright = require("whichpy.lsp.handlers.pyright").new(),
+    ty = require("whichpy.lsp.handlers.ty").new(),
   },
   after_handle_select = nil,
 }

--- a/lua/whichpy/envs.lua
+++ b/lua/whichpy/envs.lua
@@ -98,9 +98,13 @@ M.handle_select = function(selected, should_cache)
   if should_cache then
     vim.fn.mkdir(config.cache_dir, "p")
     local filename = vim.fn.getcwd():gsub("[\\/:]+", "%%")
-    local f = assert(io.open(vim.fs.joinpath(config.cache_dir, filename), "wb"))
-    f:write(selected.path .. "\n" .. selected.locator_name)
-    f:close()
+    local f, err = io.open(vim.fs.joinpath(config.cache_dir, filename), "wb")
+    if f then
+      f:write(selected.path .. "\n" .. selected.locator_name)
+      f:close()
+    else
+      util.notify("Failed to write cache: " .. err, { level = vim.log.levels.WARN })
+    end
   end
 
   if should_backup_original then

--- a/lua/whichpy/envs.lua
+++ b/lua/whichpy/envs.lua
@@ -2,9 +2,13 @@ local config = require("whichpy.config").config
 local util = require("whichpy.util")
 local is_win = util.is_win
 local SearchJob = require("whichpy.search")
+---@type WhichPy.InterpreterInfo[]
 local final_envs = {}
+---@type table?
 local orig_interpreter_path
+---@type string?
 local curr_interpreter_path
+---@type string?
 local env_name = nil
 local InterpreterInfo = require("whichpy.locator").InterpreterInfo
 
@@ -14,10 +18,12 @@ M.asearch = function()
   SearchJob:start()
 end
 
+---@param envs WhichPy.InterpreterInfo[]
 M.set_envs = function(envs)
   final_envs = envs
 end
 
+---@return WhichPy.InterpreterInfo[]
 M.get_envs = function()
   if SearchJob:status() == "dead" then
     return final_envs
@@ -171,19 +177,25 @@ M.retrieve_cache = function()
   end
   f:close()
 
+  local locator = require("whichpy.locator").get_locator(lines[2] or "global")
+  if not locator then
+    return
+  end
   M.handle_select(
     InterpreterInfo:new({
-      locator = require("whichpy.locator").get_locator(lines[2] or "global"),
+      locator = locator,
       path = lines[1],
     }),
     false
   )
 end
 
+---@return string?
 M.current_selected = function()
   return curr_interpreter_path
 end
 
+---@return string?
 M.current_selected_name = function()
   return env_name
 end

--- a/lua/whichpy/envs.lua
+++ b/lua/whichpy/envs.lua
@@ -146,7 +146,7 @@ M.handle_reset = function()
   end
 
   -- cache
-  local filename = vim.fn.getcwd():gsub("/", "%%")
+  local filename = vim.fn.getcwd():gsub("[\\/:]+", "%%")
   os.remove(vim.fs.joinpath(config.cache_dir, filename))
 
   orig_interpreter_path = nil
@@ -154,7 +154,7 @@ M.handle_reset = function()
 end
 
 M.retrieve_cache = function()
-  local filename = vim.fn.getcwd():gsub("/", "%%")
+  local filename = vim.fn.getcwd():gsub("[\\/:]+", "%%")
   local f = io.open(vim.fs.joinpath(config.cache_dir, filename), "r")
   if not f then
     return

--- a/lua/whichpy/envs.lua
+++ b/lua/whichpy/envs.lua
@@ -1,16 +1,16 @@
 local config = require("whichpy.config").config
 local util = require("whichpy.util")
 local is_win = util.is_win
+local cache = require("whichpy.cache")
 local SearchJob = require("whichpy.search")
----@type WhichPy.InterpreterInfo[]
-local final_envs = {}
----@type table?
-local orig_interpreter_path
----@type string?
-local curr_interpreter_path
----@type string?
-local env_name = nil
 local InterpreterInfo = require("whichpy.locator").InterpreterInfo
+
+local state = {
+  envs = {}, ---@type WhichPy.InterpreterInfo[]
+  current_path = nil, ---@type string?
+  current_env_name = nil, ---@type string?
+  original = nil, ---@type table?
+}
 
 local M = {}
 
@@ -20,13 +20,13 @@ end
 
 ---@param envs WhichPy.InterpreterInfo[]
 M.set_envs = function(envs)
-  final_envs = envs
+  state.envs = envs
 end
 
 ---@return WhichPy.InterpreterInfo[]
 M.get_envs = function()
   if SearchJob:status() == "dead" then
-    return final_envs
+    return state.envs
   end
   return SearchJob._temp_envs
 end
@@ -36,43 +36,39 @@ M.show_selector = function()
 end
 
 ---@param selected WhichPy.InterpreterInfo
----@param should_cache? boolean
-M.handle_select = function(selected, should_cache)
-  local should_backup_original = orig_interpreter_path == nil
-  local _orig_interpreter_path = {}
-  should_cache = should_cache == nil or should_cache
-
-  if should_backup_original then
-    _orig_interpreter_path["dap"] = {}
-    _orig_interpreter_path["envvar"] = {
-      CONDA_PREFIX = vim.env.CONDA_PREFIX,
-      VIRTUAL_ENV = vim.env.VIRTUAL_ENV,
-    }
-  end
-
-  -- lsp
+---@param should_backup boolean
+local function apply_to_lsp(selected, should_backup)
   for lsp_name, handler in pairs(config.lsp) do
     local client = vim.lsp.get_clients({ name = lsp_name })[1]
     if client then
-      if should_backup_original then
+      if should_backup then
         handler:snapshot_settings(client)
       end
       handler:set_python_path(client, selected.path)
     end
   end
+end
 
-  -- dap
+---@param selected WhichPy.InterpreterInfo
+---@param should_backup boolean
+---@return function? orig_dap_resolve
+local function apply_to_dap(selected, should_backup)
   local ok, dap_python = pcall(require, "dap-python")
-  if ok then
-    if should_backup_original then
-      _orig_interpreter_path["dap"] = dap_python.resolve_python
-    end
-    dap_python.resolve_python = function()
-      return selected.path
-    end
+  if not ok then
+    return nil
   end
+  local orig = nil
+  if should_backup then
+    orig = dap_python.resolve_python
+  end
+  dap_python.resolve_python = function()
+    return selected.path
+  end
+  return orig
+end
 
-  -- $VIRTUAL_ENV, $CONDA_PREFIX
+---@param selected WhichPy.InterpreterInfo
+local function apply_env_vars(selected)
   local env_var = selected.env_var
   if env_var.name == "VIRTUAL_ENV" then
     vim.env.VIRTUAL_ENV = env_var.val
@@ -84,107 +80,130 @@ M.handle_select = function(selected, should_cache)
     vim.env.VIRTUAL_ENV = nil
     vim.env.CONDA_PREFIX = nil
   end
-  env_name = selected.env_var.val
+  state.current_env_name = selected.env_var.val
 
   util.notify("$VIRTUAL_ENV: " .. (vim.env.VIRTUAL_ENV or "nil"))
   util.notify("$CONDA_PREFIX: " .. (vim.env.CONDA_PREFIX or "nil"))
+end
 
-  -- $PATH
+---@param selected_path string
+local function apply_path(selected_path)
+  local delimiter = (is_win and ";") or ":"
+  if state.current_path then
+    vim.env.PATH = vim.env.PATH:gsub(vim.fs.dirname(state.current_path) .. delimiter, "", 1)
+  end
+  vim.env.PATH = vim.fs.dirname(selected_path) .. delimiter .. vim.env.PATH
+
+  util.notify("Prepend " .. vim.fs.dirname(selected_path) .. " to $PATH.")
+end
+
+local function backup_original_state()
+  state.original = {
+    envvar = {
+      CONDA_PREFIX = vim.env.CONDA_PREFIX,
+      VIRTUAL_ENV = vim.env.VIRTUAL_ENV,
+    },
+    dap = nil,
+  }
+end
+
+---@param selected WhichPy.InterpreterInfo
+---@param should_cache? boolean
+M.handle_select = function(selected, should_cache)
+  local is_first = state.original == nil
+  should_cache = should_cache == nil or should_cache
+
+  if is_first then
+    backup_original_state()
+  end
+
+  apply_to_lsp(selected, is_first)
+
+  local orig_dap = apply_to_dap(selected, is_first)
+  if is_first and orig_dap ~= nil then
+    state.original.dap = orig_dap
+  end
+
+  apply_env_vars(selected)
+
   if config.update_path_env then
-    local delimiter = (is_win and ";") or ":"
-    if not should_backup_original then
-      vim.env.PATH = vim.env.PATH:gsub(vim.fs.dirname(curr_interpreter_path) .. delimiter, "", 1)
-    end
-    vim.env.PATH = vim.fs.dirname(selected.path) .. delimiter .. vim.env.PATH
-
-    util.notify("Prepend " .. vim.fs.dirname(selected.path) .. " to $PATH.")
+    apply_path(selected.path)
   end
 
-  -- cache
   if should_cache then
-    vim.fn.mkdir(config.cache_dir, "p")
-    local filename = vim.fn.getcwd():gsub("[\\/:]+", "%%")
-    local f, err = io.open(vim.fs.joinpath(config.cache_dir, filename), "wb")
-    if f then
-      f:write(selected.path .. "\n" .. selected.locator_name)
-      f:close()
-    else
-      util.notify("Failed to write cache: " .. err, { level = vim.log.levels.WARN })
-    end
+    cache.save(config.cache_dir, selected.path, selected.locator_name)
   end
 
-  if should_backup_original then
-    orig_interpreter_path = _orig_interpreter_path
-  end
-  curr_interpreter_path = selected.path
+  state.current_path = selected.path
 
   if config.after_handle_select then
     config.after_handle_select(selected)
   end
 end
 
-M.handle_reset = function()
-  if orig_interpreter_path == nil then
-    return
-  end
-
-  -- lsp
+local function restore_lsp()
   for lsp_name, handler in pairs(config.lsp) do
     local client = vim.lsp.get_clients({ name = lsp_name })[1]
     if client then
       handler:restore_snapshot(client)
     end
   end
+end
 
-  -- dap
+local function restore_dap()
   local ok, dap_python = pcall(require, "dap-python")
   if ok then
-    dap_python.resolve_python = orig_interpreter_path.dap
+    dap_python.resolve_python = state.original.dap
   end
+end
 
-  -- $VIRTUAL_ENV, $CONDA_PREFIX
-  vim.env.VIRTUAL_ENV = orig_interpreter_path.envvar.VIRTUAL_ENV
-  vim.env.CONDA_PREFIX = orig_interpreter_path.envvar.CONDA_PREFIX
+local function restore_env_vars()
+  vim.env.VIRTUAL_ENV = state.original.envvar.VIRTUAL_ENV
+  vim.env.CONDA_PREFIX = state.original.envvar.CONDA_PREFIX
 
   util.notify("$VIRTUAL_ENV: " .. (vim.env.VIRTUAL_ENV or "nil"))
   util.notify("$CONDA_PREFIX: " .. (vim.env.CONDA_PREFIX or "nil"))
+end
 
-  -- $PATH
-  if config.update_path_env then
-    local delimiter = (is_win and ";") or ":"
-    vim.env.PATH = vim.env.PATH:gsub(vim.fs.dirname(curr_interpreter_path) .. delimiter, "", 1)
+local function restore_path()
+  local delimiter = (is_win and ";") or ":"
+  vim.env.PATH = vim.env.PATH:gsub(vim.fs.dirname(state.current_path) .. delimiter, "", 1)
+end
+
+M.handle_reset = function()
+  if state.original == nil then
+    return
   end
 
-  -- cache
-  local filename = vim.fn.getcwd():gsub("[\\/:]+", "%%")
-  os.remove(vim.fs.joinpath(config.cache_dir, filename))
+  restore_lsp()
+  restore_dap()
+  restore_env_vars()
 
-  orig_interpreter_path = nil
-  curr_interpreter_path = nil
+  if config.update_path_env then
+    restore_path()
+  end
+
+  cache.remove(config.cache_dir)
+
+  state.original = nil
+  state.current_path = nil
+  state.current_env_name = nil
 end
 
 M.retrieve_cache = function()
-  local filename = vim.fn.getcwd():gsub("[\\/:]+", "%%")
-  local f = io.open(vim.fs.joinpath(config.cache_dir, filename), "r")
-  if not f then
+  local path, locator_name = cache.load(config.cache_dir)
+  if not path then
     return
   end
-  local lines = {}
-  local line = f:read()
-  while line do
-    table.insert(lines, line)
-    line = f:read()
-  end
-  f:close()
 
-  local locator = require("whichpy.locator").get_locator(lines[2] or "global")
+  local locator = require("whichpy.locator").get_locator(locator_name or "global")
   if not locator then
     return
   end
   M.handle_select(
     InterpreterInfo:new({
       locator = locator,
-      path = lines[1],
+      path = path,
     }),
     false
   )
@@ -192,12 +211,12 @@ end
 
 ---@return string?
 M.current_selected = function()
-  return curr_interpreter_path
+  return state.current_path
 end
 
 ---@return string?
 M.current_selected_name = function()
-  return env_name
+  return state.current_env_name
 end
 
 return M

--- a/lua/whichpy/init.lua
+++ b/lua/whichpy/init.lua
@@ -2,23 +2,22 @@ local M = {}
 
 ---@param opts WhichPy.Config
 M.setup = function(opts)
-  local config = require("whichpy.config")
-  config.setup_config(opts or {})
+  require("whichpy.config").setup_config(opts or {})
   require("whichpy.usercmd").create_user_cmd()
   require("whichpy.lsp").create_autocmd()
 
-  if config.config.set_env_on_startup then
-    if vim.v.vim_did_enter == 0 then
-      M._augroup = vim.api.nvim_create_augroup("WhichPyStartup", { clear = true })
-      vim.api.nvim_create_autocmd({ "VimEnter" }, {
-        group = M._augroup,
-        callback = function()
+  -- Commands that emit output should wait until startup is complete
+  -- to ensure notifications etc are set up.
+  if vim.v.vim_did_enter == 0 then
+    M._augroup = vim.api.nvim_create_augroup("WhichPyStartup", { clear = true })
+    vim.api.nvim_create_autocmd({ "VimEnter" }, {
+      group = M._augroup,
+      callback = function()
         require("whichpy.envs").retrieve_cache()
-        end
-      })
-    else
-      require("whichpy.envs").retrieve_cache()
-    end
+      end,
+    })
+  else
+    require("whichpy.envs").retrieve_cache()
   end
 end
 

--- a/lua/whichpy/init.lua
+++ b/lua/whichpy/init.lua
@@ -2,10 +2,24 @@ local M = {}
 
 ---@param opts WhichPy.Config
 M.setup = function(opts)
-  require("whichpy.config").setup_config(opts or {})
+  local config = require("whichpy.config")
+  config.setup_config(opts or {})
   require("whichpy.usercmd").create_user_cmd()
   require("whichpy.lsp").create_autocmd()
-  require("whichpy.envs").retrieve_cache()
+
+  if config.config.set_env_on_startup then
+    if vim.v.vim_did_enter == 0 then
+      M._augroup = vim.api.nvim_create_augroup("WhichPyStartup", { clear = true })
+      vim.api.nvim_create_autocmd({ "VimEnter" }, {
+        group = M._augroup,
+        callback = function()
+        require("whichpy.envs").retrieve_cache()
+        end
+      })
+    else
+      require("whichpy.envs").retrieve_cache()
+    end
+  end
 end
 
 return M

--- a/lua/whichpy/init.lua
+++ b/lua/whichpy/init.lua
@@ -15,7 +15,7 @@ M.setup = function(opts)
       callback = function()
         vim.defer_fn(function()
           require("whichpy.envs").retrieve_cache()
-        end, 50)
+        end, 200)
       end,
     })
   else

--- a/lua/whichpy/init.lua
+++ b/lua/whichpy/init.lua
@@ -10,10 +10,12 @@ M.setup = function(opts)
   -- to ensure notifications etc are set up.
   if vim.v.vim_did_enter == 0 then
     M._augroup = vim.api.nvim_create_augroup("WhichPyStartup", { clear = true })
-    vim.api.nvim_create_autocmd({ "VimEnter" }, {
+    vim.api.nvim_create_autocmd({ "UIEnter" }, {
       group = M._augroup,
       callback = function()
-        require("whichpy.envs").retrieve_cache()
+        vim.defer_fn(function()
+          require("whichpy.envs").retrieve_cache()
+        end, 50)
       end,
     })
   else

--- a/lua/whichpy/locator/_common.lua
+++ b/lua/whichpy/locator/_common.lua
@@ -228,6 +228,9 @@ local InterpreterInfo = require("whichpy.locator").InterpreterInfo
 ---@return fun(): WhichPy.InterpreterInfo?
 function M.find_interpreters_in_dir(locator, dir)
   return coroutine.wrap(function()
+    if not vim.uv.fs_stat(dir) then
+      return
+    end
     for name, t in vim.fs.dir(dir) do
       if t == "directory" then
         local path = get_interpreter_path(vim.fs.joinpath(dir, name), "bin")

--- a/lua/whichpy/locator/_common.lua
+++ b/lua/whichpy/locator/_common.lua
@@ -65,8 +65,7 @@ function M.get_search_path_entries()
   dirs = vim
     .iter(dirs)
     :filter(function(dir)
-      return dir ~= pyenv_shims
-        and (exclude_path == nil or exclude_path ~= nil and dir ~= exclude_path)
+      return dir ~= pyenv_shims and (exclude_path == nil or dir ~= exclude_path)
     end)
     :map(function(dir)
       return vim.fn.fnamemodify(dir, ":p")

--- a/lua/whichpy/locator/_common.lua
+++ b/lua/whichpy/locator/_common.lua
@@ -180,7 +180,7 @@ function M.async_find(opts)
       return
     end
 
-    vim.system(opts.cmd, {}, function(out)
+    vim.system(opts.cmd, { timeout = 10000 }, function(out)
       local ctx = { locator_name = opts.locator.name }
 
       if out.code ~= 0 then

--- a/lua/whichpy/locator/_common.lua
+++ b/lua/whichpy/locator/_common.lua
@@ -165,4 +165,60 @@ function M.get_env_var_strategy.guess(python_path)
   return {}
 end
 
+---@class WhichPy.AsyncFindOpts
+---@field locator table
+---@field Job table
+---@field cmd string[]
+---@field parse_output fun(stdout: string): any?
+---@field err_msg string
+---@field find_fn fun(locator: table, data: any): fun(): WhichPy.InterpreterInfo?
+
+---Shared async find pattern for locators that run an external command.
+---@param opts WhichPy.AsyncFindOpts
+function M.async_find(opts)
+  return coroutine.wrap(function()
+    if vim.fn.executable(opts.cmd[1]) == 0 then
+      return
+    end
+
+    vim.system(opts.cmd, {}, function(out)
+      local ctx = { locator_name = opts.locator.name }
+
+      if out.code ~= 0 then
+        ctx.err = opts.err_msg
+      else
+        local data = opts.parse_output(out.stdout)
+        if data then
+          ctx.co = function()
+            return opts.find_fn(opts.locator, data)
+          end
+        end
+      end
+
+      opts.Job:continue(ctx)
+    end)
+
+    coroutine.yield({ locator_name = opts.locator.name, wait = true })
+  end)
+end
+
+local get_interpreter_path = util.get_interpreter_path
+local InterpreterInfo = require("whichpy.locator").InterpreterInfo
+
+---Shared _find for locators that scan a directory for subdirectories containing a Python interpreter.
+---@param locator table
+---@param dir string
+function M.find_interpreters_in_dir(locator, dir)
+  return coroutine.wrap(function()
+    for name, t in vim.fs.dir(dir) do
+      if t == "directory" then
+        local path = get_interpreter_path(vim.fs.joinpath(dir, name), "bin")
+        if vim.uv.fs_stat(path) then
+          coroutine.yield(InterpreterInfo:new({ locator = locator, path = path }))
+        end
+      end
+    end
+  end)
+end
+
 return M

--- a/lua/whichpy/locator/_common.lua
+++ b/lua/whichpy/locator/_common.lua
@@ -4,6 +4,7 @@ local config = require("whichpy.config").config
 
 local M = {}
 
+---@return string
 function M.get_pyenv_dir()
   local pyenv_root = is_win and os.getenv("PYENV") or os.getenv("PYENV_ROOT")
   if pyenv_root == nil or pyenv_root == "" then
@@ -14,10 +15,12 @@ function M.get_pyenv_dir()
   return pyenv_root
 end
 
+---@return string
 function M.get_pyenv_version_dir()
   return vim.fs.joinpath(M.get_pyenv_dir(), "versions")
 end
 
+---@return string
 function M.get_pyenv_shims_dir()
   return vim.fs.joinpath(M.get_pyenv_dir(), "shims")
 end
@@ -48,6 +51,7 @@ local common_posix_bin_paths = {
   "~/.local/bin",
 }
 
+---@return string[]
 function M.get_search_path_entries()
   local delimiter = (is_win and ";") or ":"
   local dirs = vim.split(vim.env.PATH or vim.env.Path, delimiter)
@@ -74,6 +78,8 @@ function M.get_search_path_entries()
   return util.deduplicate(dirs)
 end
 
+---@param opts_dirs (string|string[])[]
+---@return string[]
 function M.get_global_virtual_environment_dirs(opts_dirs)
   local sysname = vim.uv.os_uname().sysname
   local dirs = {}
@@ -90,6 +96,7 @@ function M.get_global_virtual_environment_dirs(opts_dirs)
   return util.deduplicate(dirs)
 end
 
+---@return string[]
 function M.get_workspace_folders()
   local hash = {}
   local res = {}
@@ -111,12 +118,16 @@ function M.get_workspace_folders()
   return res
 end
 
+---@type table<string, fun(python_path?: string): WhichPy.EnvVar>
 M.get_env_var_strategy = {}
 
+---@return WhichPy.EnvVar
 function M.get_env_var_strategy.no()
   return {}
 end
 
+---@param python_path string
+---@return WhichPy.EnvVar
 function M.get_env_var_strategy.conda(python_path)
   local prefix = vim.fs.dirname(python_path)
   if not is_win then
@@ -125,6 +136,8 @@ function M.get_env_var_strategy.conda(python_path)
   return { name = "CONDA_PREFIX", val = prefix }
 end
 
+---@param python_path string
+---@return WhichPy.EnvVar
 function M.get_env_var_strategy.pyenv(python_path)
   local venv = vim.fs.dirname(vim.fs.dirname(python_path))
   local pyvenv_cfg = vim.fs.joinpath(venv, "pyvenv.cfg")
@@ -134,10 +147,14 @@ function M.get_env_var_strategy.pyenv(python_path)
   return {}
 end
 
+---@param python_path string
+---@return WhichPy.EnvVar
 function M.get_env_var_strategy.virtual_env(python_path)
   return { name = "VIRTUAL_ENV", val = vim.fs.dirname(vim.fs.dirname(python_path)) }
 end
 
+---@param python_path string
+---@return WhichPy.EnvVar
 function M.get_env_var_strategy.guess(python_path)
   local venv = vim.fs.dirname(vim.fs.dirname(python_path))
   if vim.startswith(python_path, M.get_pyenv_version_dir()) then
@@ -165,15 +182,16 @@ function M.get_env_var_strategy.guess(python_path)
 end
 
 ---@class WhichPy.AsyncFindOpts
----@field locator table
----@field Job table
+---@field locator WhichPy.Locator
+---@field Job WhichPy.SearchJob
 ---@field cmd string[]
 ---@field parse_output fun(stdout: string): any?
 ---@field err_msg string
----@field find_fn fun(locator: table, data: any): fun(): WhichPy.InterpreterInfo?
+---@field find_fn fun(locator: WhichPy.Locator, data: any): fun(): WhichPy.InterpreterInfo?
 
 ---Shared async find pattern for locators that run an external command.
 ---@param opts WhichPy.AsyncFindOpts
+---@return fun(): WhichPy.Ctx|WhichPy.InterpreterInfo
 function M.async_find(opts)
   return coroutine.wrap(function()
     if vim.fn.executable(opts.cmd[1]) == 0 then
@@ -205,8 +223,9 @@ local get_interpreter_path = util.get_interpreter_path
 local InterpreterInfo = require("whichpy.locator").InterpreterInfo
 
 ---Shared _find for locators that scan a directory for subdirectories containing a Python interpreter.
----@param locator table
+---@param locator WhichPy.Locator
 ---@param dir string
+---@return fun(): WhichPy.InterpreterInfo?
 function M.find_interpreters_in_dir(locator, dir)
   return coroutine.wrap(function()
     for name, t in vim.fs.dir(dir) do

--- a/lua/whichpy/locator/conda.lua
+++ b/lua/whichpy/locator/conda.lua
@@ -1,7 +1,8 @@
 local util = require("whichpy.util")
 local is_win = util.is_win
 local get_interpreter_path = util.get_interpreter_path
-local get_env_var_strategy = require("whichpy.locator._common").get_env_var_strategy
+local common = require("whichpy.locator._common")
+local get_env_var_strategy = common.get_env_var_strategy
 local InterpreterInfo = require("whichpy.locator").InterpreterInfo
 
 ---@class WhichPy.Locator.Conda: WhichPy.Locator
@@ -20,46 +21,29 @@ function Locator.new(opts)
 end
 
 function Locator:find(Job)
-  return coroutine.wrap(function()
-    if vim.fn.executable("conda") == 0 then
-      return
-    end
-
-    vim.system({ "conda", "info", "--json" }, {}, function(out)
-      local ctx = { locator_name = self.name }
-
-      if out.code ~= 0 then
-        ctx.err = "conda command error"
-      else
-        local ok, envs = pcall(vim.json.decode, out.stdout)
-        if ok then
-          envs = envs.envs
-          if envs then
-            ctx.co = function()
-              return self:_find(envs)
-            end
+  return common.async_find({
+    locator = self,
+    Job = Job,
+    cmd = { "conda", "info", "--json" },
+    parse_output = function(stdout)
+      local ok, result = pcall(vim.json.decode, stdout)
+      if not ok then
+        return nil
+      end
+      return result.envs
+    end,
+    err_msg = "conda command error",
+    find_fn = function(locator, envs)
+      return coroutine.wrap(function()
+        for _, env in ipairs(envs) do
+          local path = get_interpreter_path(env, is_win and "root" or "bin")
+          if vim.uv.fs_stat(path) then
+            coroutine.yield(InterpreterInfo:new({ locator = locator, path = path }))
           end
-        else
-          ctx.err = "conda output isn't json."
         end
-      end
-
-      Job:continue(ctx)
-    end)
-
-    coroutine.yield({ locator_name = self.name, wait = true })
-  end)
-end
-
-function Locator:_find(envs)
-  return coroutine.wrap(function()
-    for _, env in ipairs(envs) do
-      local path = get_interpreter_path(env, is_win and "root" or "bin")
-      if vim.uv.fs_stat(path) then
-        coroutine.yield(InterpreterInfo:new({ locator = self, path = path }))
-      end
-    end
-  end)
+      end)
+    end,
+  })
 end
 
 return Locator

--- a/lua/whichpy/locator/conda.lua
+++ b/lua/whichpy/locator/conda.lua
@@ -12,6 +12,8 @@ local InterpreterInfo = require("whichpy.locator").InterpreterInfo
 local Locator = { name = "conda" }
 Locator.__index = Locator
 
+---@param opts? WhichPy.Locator.Conda.Opts
+---@return WhichPy.Locator.Conda
 function Locator.new(opts)
   local obj = vim.tbl_deep_extend("force", {
     display_name = "Conda",
@@ -20,6 +22,8 @@ function Locator.new(opts)
   return setmetatable(obj, Locator)
 end
 
+---@param Job WhichPy.SearchJob
+---@return fun(): WhichPy.Ctx|WhichPy.InterpreterInfo
 function Locator:find(Job)
   return common.async_find({
     locator = self,

--- a/lua/whichpy/locator/global.lua
+++ b/lua/whichpy/locator/global.lua
@@ -11,6 +11,8 @@ local InterpreterInfo = require("whichpy.locator").InterpreterInfo
 local Locator = { name = "global" }
 Locator.__index = Locator
 
+---@param opts? WhichPy.Locator.Global.Opts
+---@return WhichPy.Locator.Global
 function Locator.new(opts)
   local obj = vim.tbl_deep_extend("force", {
     display_name = "Global",
@@ -19,6 +21,7 @@ function Locator.new(opts)
   return setmetatable(obj, Locator)
 end
 
+---@return fun(): WhichPy.InterpreterInfo?
 function Locator:find()
   return coroutine.wrap(function()
     local dirs = get_search_path_entries()

--- a/lua/whichpy/locator/global_virtual_environment.lua
+++ b/lua/whichpy/locator/global_virtual_environment.lua
@@ -16,7 +16,7 @@ Locator.__index = Locator
 
 function Locator.new(opts)
   local obj = vim.tbl_deep_extend("force", {
-    display_name = "Global Virtual Environemnt",
+    display_name = "Global Virtual Environment",
     get_env_var_strategy = get_env_var_strategy.virtual_env,
     dirs = {
       "~/envs",

--- a/lua/whichpy/locator/global_virtual_environment.lua
+++ b/lua/whichpy/locator/global_virtual_environment.lua
@@ -14,6 +14,8 @@ local InterpreterInfo = require("whichpy.locator").InterpreterInfo
 local Locator = { name = "global_virtual_environment" }
 Locator.__index = Locator
 
+---@param opts? WhichPy.Locator.GlobalVirtualEnvironment.Opts
+---@return WhichPy.Locator.GlobalVirtualEnvironment
 function Locator.new(opts)
   local obj = vim.tbl_deep_extend("force", {
     display_name = "Global Virtual Environment",
@@ -31,6 +33,7 @@ function Locator.new(opts)
   return setmetatable(obj, Locator)
 end
 
+---@return fun(): WhichPy.InterpreterInfo?
 function Locator:find()
   return coroutine.wrap(function()
     local dirs = get_global_virtual_environment_dirs(self.dirs)

--- a/lua/whichpy/locator/init.lua
+++ b/lua/whichpy/locator/init.lua
@@ -1,13 +1,18 @@
 local config = require("whichpy.config").config
 
+---@class WhichPy.EnvVar
+---@field name? string
+---@field val? string
+
 ---@class WhichPy.Locator
----@field private name string
+---@field name string
 ---@field display_name string
----@field get_env_var_strategy fun(path: string): table<string,string>
+---@field get_env_var_strategy fun(path: string): WhichPy.EnvVar
 
 ---@class WhichPy.Locator.Opts
+---@field enable? boolean
 ---@field display_name? string
----@field get_env_var_strategy? fun(path: string): table<string,string>
+---@field get_env_var_strategy? fun(path: string): WhichPy.EnvVar
 
 local M = {}
 
@@ -15,7 +20,7 @@ local M = {}
 M.locators = {}
 
 ---@param locator_name string
----@param locator_opts table
+---@param locator_opts WhichPy.Locator.Opts
 M.setup_locator = function(locator_name, locator_opts)
   if locator_opts.enable == false then
     return
@@ -29,6 +34,8 @@ M.setup_locator = function(locator_name, locator_opts)
   M.locators[locator_name] = locator.new(locator_opts)
 end
 
+---@param locator_name string
+---@return WhichPy.Locator?
 function M.get_locator(locator_name)
   local ok, locator = pcall(require, "whichpy.locator." .. locator_name)
   if not ok then
@@ -40,12 +47,16 @@ function M.get_locator(locator_name)
 end
 
 ---@class WhichPy.InterpreterInfo
----@field locator_name WhichPy.Locator
+---@field locator_name string
 ---@field path string
----@field env_var table<string,string>
+---@field env_var WhichPy.EnvVar
 M.InterpreterInfo = {}
 
----@param opts any
+---@class WhichPy.InterpreterInfo.NewOpts
+---@field locator WhichPy.Locator
+---@field path string
+
+---@param opts WhichPy.InterpreterInfo.NewOpts
 ---@return WhichPy.InterpreterInfo
 function M.InterpreterInfo:new(opts)
   return setmetatable({

--- a/lua/whichpy/locator/init.lua
+++ b/lua/whichpy/locator/init.lua
@@ -8,6 +8,7 @@ local config = require("whichpy.config").config
 ---@field name string
 ---@field display_name string
 ---@field get_env_var_strategy fun(path: string): WhichPy.EnvVar
+---@field find fun(self: WhichPy.Locator, Job: WhichPy.SearchJob): fun(): WhichPy.Ctx|WhichPy.InterpreterInfo
 
 ---@class WhichPy.Locator.Opts
 ---@field enable? boolean

--- a/lua/whichpy/locator/pdm.lua
+++ b/lua/whichpy/locator/pdm.lua
@@ -1,6 +1,5 @@
-local get_interpreter_path = require("whichpy.util").get_interpreter_path
-local get_env_var_strategy = require("whichpy.locator._common").get_env_var_strategy
-local InterpreterInfo = require("whichpy.locator").InterpreterInfo
+local common = require("whichpy.locator._common")
+local get_env_var_strategy = common.get_env_var_strategy
 
 ---@class WhichPy.Locator.Pdm: WhichPy.Locator
 
@@ -18,43 +17,17 @@ function Locator.new(opts)
 end
 
 function Locator:find(Job)
-  return coroutine.wrap(function()
-    if vim.fn.executable("pdm") == 0 then
-      return
-    end
-
-    vim.system({ "pdm", "config", "venv.location" }, {}, function(out)
-      local ctx = { locator_name = self.name }
-
-      if out.code ~= 0 then
-        ctx.err = "pdm command error"
-      else
-        local dir = vim.trim(out.stdout)
-        if dir ~= "" then
-          ctx.co = function()
-            return self:_find(dir)
-          end
-        end
-      end
-
-      Job:continue(ctx)
-    end)
-
-    coroutine.yield({ locator_name = self.name, wait = true })
-  end)
-end
-
-function Locator:_find(dir)
-  return coroutine.wrap(function()
-    for name, t in vim.fs.dir(dir) do
-      if t == "directory" then
-        local path = get_interpreter_path(vim.fs.joinpath(dir, name), "bin")
-        if vim.uv.fs_stat(path) then
-          coroutine.yield(InterpreterInfo:new({ locator = self, path = path }))
-        end
-      end
-    end
-  end)
+  return common.async_find({
+    locator = self,
+    Job = Job,
+    cmd = { "pdm", "config", "venv.location" },
+    parse_output = function(stdout)
+      local dir = vim.trim(stdout)
+      return dir ~= "" and dir or nil
+    end,
+    err_msg = "pdm command error",
+    find_fn = common.find_interpreters_in_dir,
+  })
 end
 
 return Locator

--- a/lua/whichpy/locator/pdm.lua
+++ b/lua/whichpy/locator/pdm.lua
@@ -8,6 +8,8 @@ local get_env_var_strategy = common.get_env_var_strategy
 local Locator = { name = "pdm" }
 Locator.__index = Locator
 
+---@param opts? WhichPy.Locator.Pdm.Opts
+---@return WhichPy.Locator.Pdm
 function Locator.new(opts)
   local obj = vim.tbl_deep_extend("force", {
     display_name = "PDM",
@@ -16,6 +18,8 @@ function Locator.new(opts)
   return setmetatable(obj, Locator)
 end
 
+---@param Job WhichPy.SearchJob
+---@return fun(): WhichPy.Ctx|WhichPy.InterpreterInfo
 function Locator:find(Job)
   return common.async_find({
     locator = self,

--- a/lua/whichpy/locator/poetry.lua
+++ b/lua/whichpy/locator/poetry.lua
@@ -8,6 +8,8 @@ local get_env_var_strategy = common.get_env_var_strategy
 local Locator = { name = "poetry" }
 Locator.__index = Locator
 
+---@param opts? WhichPy.Locator.Poetry.Opts
+---@return WhichPy.Locator.Poetry
 function Locator.new(opts)
   local obj = vim.tbl_deep_extend("force", {
     display_name = "Poetry",
@@ -16,6 +18,8 @@ function Locator.new(opts)
   return setmetatable(obj, Locator)
 end
 
+---@param Job WhichPy.SearchJob
+---@return fun(): WhichPy.Ctx|WhichPy.InterpreterInfo
 function Locator:find(Job)
   return common.async_find({
     locator = self,

--- a/lua/whichpy/locator/poetry.lua
+++ b/lua/whichpy/locator/poetry.lua
@@ -1,6 +1,5 @@
-local get_interpreter_path = require("whichpy.util").get_interpreter_path
-local get_env_var_strategy = require("whichpy.locator._common").get_env_var_strategy
-local InterpreterInfo = require("whichpy.locator").InterpreterInfo
+local common = require("whichpy.locator._common")
+local get_env_var_strategy = common.get_env_var_strategy
 
 ---@class WhichPy.Locator.Poetry: WhichPy.Locator
 
@@ -18,43 +17,17 @@ function Locator.new(opts)
 end
 
 function Locator:find(Job)
-  return coroutine.wrap(function()
-    if vim.fn.executable("poetry") == 0 then
-      return
-    end
-
-    vim.system({ "poetry", "config", "virtualenvs.path" }, {}, function(out)
-      local ctx = { locator_name = self.name }
-
-      if out.code ~= 0 then
-        ctx.err = "poetry command error"
-      else
-        local dir = vim.trim(out.stdout)
-        if dir ~= "" then
-          ctx.co = function()
-            return self:_find(dir)
-          end
-        end
-      end
-
-      Job:continue(ctx)
-    end)
-
-    coroutine.yield({ locator_name = self.name, wait = true })
-  end)
-end
-
-function Locator:_find(dir)
-  return coroutine.wrap(function()
-    for name, t in vim.fs.dir(dir) do
-      if t == "directory" then
-        local path = get_interpreter_path(vim.fs.joinpath(dir, name), "bin")
-        if vim.uv.fs_stat(path) then
-          coroutine.yield(InterpreterInfo:new({ locator = self, path = path }))
-        end
-      end
-    end
-  end)
+  return common.async_find({
+    locator = self,
+    Job = Job,
+    cmd = { "poetry", "config", "virtualenvs.path" },
+    parse_output = function(stdout)
+      local dir = vim.trim(stdout)
+      return dir ~= "" and dir or nil
+    end,
+    err_msg = "poetry command error",
+    find_fn = common.find_interpreters_in_dir,
+  })
 end
 
 return Locator

--- a/lua/whichpy/locator/pyenv.lua
+++ b/lua/whichpy/locator/pyenv.lua
@@ -12,6 +12,8 @@ local InterpreterInfo = require("whichpy.locator").InterpreterInfo
 local Locator = { name = "pyenv" }
 Locator.__index = Locator
 
+---@param opts? WhichPy.Locator.Pyenv.Opts
+---@return WhichPy.Locator.Pyenv
 function Locator.new(opts)
   local obj = vim.tbl_deep_extend("force", {
     display_name = "Pyenv",
@@ -21,6 +23,7 @@ function Locator.new(opts)
   return setmetatable(obj, Locator)
 end
 
+---@return fun(): WhichPy.InterpreterInfo?
 function Locator:find()
   return coroutine.wrap(function()
     local dir = get_pyenv_version_dir()

--- a/lua/whichpy/locator/pyenv.lua
+++ b/lua/whichpy/locator/pyenv.lua
@@ -35,10 +35,9 @@ function Locator:find()
 
           local envs_dir = vim.fs.joinpath(dir, name, "envs")
 
-          ---@diagnostic disable-next-line: redefined-local
-          for name, t in vim.fs.dir(envs_dir) do
-            if t == "directory" then
-              path = get_interpreter_path(vim.fs.joinpath(envs_dir, name), "bin")
+          for venv_name, venv_type in vim.fs.dir(envs_dir) do
+            if venv_type == "directory" then
+              path = get_interpreter_path(vim.fs.joinpath(envs_dir, venv_name), "bin")
               if vim.uv.fs_stat(path) then
                 coroutine.yield(InterpreterInfo:new({ locator = self, path = path }))
               end

--- a/lua/whichpy/locator/uv.lua
+++ b/lua/whichpy/locator/uv.lua
@@ -8,6 +8,8 @@ local get_env_var_strategy = common.get_env_var_strategy
 local Locator = { name = "uv" }
 Locator.__index = Locator
 
+---@param opts? WhichPy.Locator.Uv.Opts
+---@return WhichPy.Locator.Uv
 function Locator.new(opts)
   local obj = vim.tbl_deep_extend("force", {
     display_name = "uv",
@@ -16,6 +18,8 @@ function Locator.new(opts)
   return setmetatable(obj, Locator)
 end
 
+---@param Job WhichPy.SearchJob
+---@return fun(): WhichPy.Ctx|WhichPy.InterpreterInfo
 function Locator:find(Job)
   return common.async_find({
     locator = self,

--- a/lua/whichpy/locator/uv.lua
+++ b/lua/whichpy/locator/uv.lua
@@ -1,6 +1,5 @@
-local get_interpreter_path = require("whichpy.util").get_interpreter_path
-local get_env_var_strategy = require("whichpy.locator._common").get_env_var_strategy
-local InterpreterInfo = require("whichpy.locator").InterpreterInfo
+local common = require("whichpy.locator._common")
+local get_env_var_strategy = common.get_env_var_strategy
 
 ---@class WhichPy.Locator.Uv: WhichPy.Locator
 
@@ -18,43 +17,17 @@ function Locator.new(opts)
 end
 
 function Locator:find(Job)
-  return coroutine.wrap(function()
-    if vim.fn.executable("uv") == 0 then
-      return
-    end
-
-    vim.system({ "uv", "python", "dir" }, {}, function(out)
-      local ctx = { locator_name = self.name }
-
-      if out.code ~= 0 then
-        ctx.err = "uv command error"
-      else
-        local dir = vim.trim(out.stdout)
-        if dir ~= "" then
-          ctx.co = function()
-            return self:_find(dir)
-          end
-        end
-      end
-
-      Job:continue(ctx)
-    end)
-
-    coroutine.yield({ locator_name = self.name, wait = true })
-  end)
-end
-
-function Locator:_find(dir)
-  return coroutine.wrap(function()
-    for name, t in vim.fs.dir(dir) do
-      if t == "directory" then
-        local path = get_interpreter_path(vim.fs.joinpath(dir, name), "bin")
-        if vim.uv.fs_stat(path) then
-          coroutine.yield(InterpreterInfo:new({ locator = self, path = path }))
-        end
-      end
-    end
-  end)
+  return common.async_find({
+    locator = self,
+    Job = Job,
+    cmd = { "uv", "python", "dir" },
+    parse_output = function(stdout)
+      local dir = vim.trim(stdout)
+      return dir ~= "" and dir or nil
+    end,
+    err_msg = "uv command error",
+    find_fn = common.find_interpreters_in_dir,
+  })
 end
 
 return Locator

--- a/lua/whichpy/locator/workspace.lua
+++ b/lua/whichpy/locator/workspace.lua
@@ -16,6 +16,8 @@ local get_workspace_folders = require("whichpy.locator._common").get_workspace_f
 local Locator = { name = "workspace" }
 Locator.__index = Locator
 
+---@param opts? WhichPy.Locator.Workspace.Opts
+---@return WhichPy.Locator.Workspace
 function Locator.new(opts)
   local obj = vim.tbl_deep_extend("force", {
     display_name = "Workspace",
@@ -34,6 +36,7 @@ function Locator.new(opts)
   return setmetatable(obj, Locator)
 end
 
+---@return fun(): WhichPy.InterpreterInfo?
 function Locator:find()
   local dirs = vim
     .iter(get_workspace_folders())

--- a/lua/whichpy/lsp.lua
+++ b/lua/whichpy/lsp.lua
@@ -1,9 +1,17 @@
+---@class WhichPy.Lsp.ClientState
+---@field client_id integer
+---@field last_selected string?
+
 local M = {
-  _augroup = {},
+  ---@type integer
+  _augroup = 0,
+  ---@type table<string, WhichPy.Lsp.ClientState>
   _clients = {},
+  ---@type table<string, boolean>
   _restart_by_whichpy = {},
 }
 
+---@param args { data: { client_id: integer } }
 function M.lsp_attach_callback(args)
   local client_id = args["data"]["client_id"]
   local client = vim.lsp.get_client_by_id(client_id)
@@ -29,7 +37,7 @@ function M.lsp_attach_callback(args)
   local is_new_client = client_state == nil
   local is_same_client = not is_new_client and client_state.client_id == client_id
 
-  if not is_same_client and has_selected then
+  if not is_same_client and selected then
     if is_new_client then
       config.lsp[client_name]:snapshot_settings(client)
     end
@@ -58,6 +66,7 @@ function M.create_autocmd()
   })
 end
 
+---@param client vim.lsp.Client
 function M.skip_next_set_python_path(client)
   M._restart_by_whichpy[client.name] = true
 end

--- a/lua/whichpy/lsp.lua
+++ b/lua/whichpy/lsp.lua
@@ -34,14 +34,7 @@ function M.lsp_attach_callback(args)
       config.lsp[client_name]:snapshot_settings(client)
     end
 
-    if
-      not M._restart_by_whichpy[client.name]
-      and (
-        is_new_client
-        or not is_same_client
-        or (is_same_client and client_state.last_selected ~= selected)
-      )
-    then
+    if not M._restart_by_whichpy[client.name] then
       config.lsp[client_name]:set_python_path(client, selected)
     end
 

--- a/lua/whichpy/lsp.lua
+++ b/lua/whichpy/lsp.lua
@@ -63,4 +63,3 @@ function M.skip_next_set_python_path(client)
 end
 
 return M
-

--- a/lua/whichpy/lsp/handlers/pylsp.lua
+++ b/lua/whichpy/lsp/handlers/pylsp.lua
@@ -1,9 +1,10 @@
 ---@class WhichPy.Lsp.PylspHandler: WhichPy.Lsp.Handler
----@field snapshot? table
----@field server_default? table
+---@field snapshot? { jedi_environment: string?, mypy_overrides: any[] }
+---@field server_default { jedi_environment: string?, mypy_overrides: any[] }
 local M = {}
 M.__index = M
 
+---@return WhichPy.Lsp.PylspHandler
 function M.new()
   local obj = {
     server_default = {

--- a/lua/whichpy/lsp/handlers/pyright.lua
+++ b/lua/whichpy/lsp/handlers/pyright.lua
@@ -38,7 +38,7 @@ function M:set_python_path(client, python_path)
       vim.tbl_deep_extend("force", client.settings, { python = { pythonPath = python_path } })
     client.notify("workspace/didChangeConfiguration", { settings = nil })
   else
-    vim.cmd(("LspRestart %s"):format(client.id))
+    vim.cmd(("LspRestart %s"):format(client.name))
   end
 end
 

--- a/lua/whichpy/lsp/handlers/pyright.lua
+++ b/lua/whichpy/lsp/handlers/pyright.lua
@@ -1,9 +1,10 @@
 ---@class WhichPy.Lsp.PyrightHandler: WhichPy.Lsp.Handler
----@field snapshot? table
----@field server_default? table
+---@field snapshot? { python_path: string? }
+---@field server_default { python_path: string? }
 local M = {}
 M.__index = M
 
+---@return WhichPy.Lsp.PyrightHandler
 function M.new()
   local obj = {
     server_default = {

--- a/lua/whichpy/lsp/handlers/pyright.lua
+++ b/lua/whichpy/lsp/handlers/pyright.lua
@@ -39,7 +39,7 @@ function M:set_python_path(client, python_path)
       vim.tbl_deep_extend("force", client.settings, { python = { pythonPath = python_path } })
     client.notify("workspace/didChangeConfiguration", { settings = nil })
   else
-    vim.cmd(("LspRestart %s"):format(client.name))
+    vim.cmd(("lsp restart %s"):format(client.name))
   end
 end
 

--- a/lua/whichpy/lsp/handlers/ty.lua
+++ b/lua/whichpy/lsp/handlers/ty.lua
@@ -1,0 +1,26 @@
+---@class WhichPy.Lsp.TyHandler: WhichPy.Lsp.Handler
+---@field snapshot? table
+---@field server_default? table
+local M = {}
+M.__index = M
+
+function M.new()
+  return setmetatable({}, M)
+end
+
+function M:snapshot_settings(_)
+  --
+end
+
+function M:restore_snapshot(client)
+  self:set_python_path(client, nil)
+end
+
+function M:set_python_path(client, _)
+  vim.defer_fn(function ()
+    require("whichpy.lsp").skip_next_set_python_path(client)
+    vim.cmd(("LspRestart %s"):format(client.name))
+  end, 200)
+end
+
+return M

--- a/lua/whichpy/lsp/handlers/ty.lua
+++ b/lua/whichpy/lsp/handlers/ty.lua
@@ -1,9 +1,8 @@
 ---@class WhichPy.Lsp.TyHandler: WhichPy.Lsp.Handler
----@field snapshot? table
----@field server_default? table
 local M = {}
 M.__index = M
 
+---@return WhichPy.Lsp.TyHandler
 function M.new()
   return setmetatable({}, M)
 end

--- a/lua/whichpy/lsp/handlers/ty.lua
+++ b/lua/whichpy/lsp/handlers/ty.lua
@@ -18,7 +18,7 @@ end
 function M:set_python_path(client, _)
   vim.defer_fn(function()
     require("whichpy.lsp").skip_next_set_python_path(client)
-    vim.cmd(("LspRestart %s"):format(client.name))
+    vim.cmd(("lsp restart %s"):format(client.name))
   end, 200)
 end
 

--- a/lua/whichpy/lsp/handlers/ty.lua
+++ b/lua/whichpy/lsp/handlers/ty.lua
@@ -17,7 +17,7 @@ function M:restore_snapshot(client)
 end
 
 function M:set_python_path(client, _)
-  vim.defer_fn(function ()
+  vim.defer_fn(function()
     require("whichpy.lsp").skip_next_set_python_path(client)
     vim.cmd(("LspRestart %s"):format(client.name))
   end, 200)

--- a/lua/whichpy/picker/init.lua
+++ b/lua/whichpy/picker/init.lua
@@ -1,13 +1,13 @@
 local util = require("whichpy.util")
 
 ---@class WhichPy.Picker
----@field setup function
----@field show function
+---@field setup fun(self: WhichPy.Picker): table
+---@field show fun(self: WhichPy.Picker)
 
 local M = {}
 setmetatable(M, {
   __index = function(_, key)
-    if key == "fzf-lua" or key == "telescope" then
+    if key == "fzf-lua" or key == "telescope" or key == "snacks" then
       if util.is_support(key) then
         return require("whichpy.picker." .. key)
       end

--- a/lua/whichpy/picker/snacks.lua
+++ b/lua/whichpy/picker/snacks.lua
@@ -1,0 +1,85 @@
+local SearchJob = require("whichpy.search")
+local config = require("whichpy.config").config
+local handle_select = require("whichpy.envs").handle_select
+local get_envs = require("whichpy.envs").get_envs
+
+local Picker = {}
+
+function Picker:setup()
+  return vim.tbl_deep_extend(
+    "force",
+    {
+      prompt = " ",
+      title = "Select Python Interpreter",
+      format = "text",
+      layout = {
+          hidden = { "preview" },
+      }
+    },
+    config.picker["snacks"] or {}
+  )
+end
+
+function Picker:show()
+  local snacks_ok, snacks = pcall(require, "snacks")
+  if not snacks_ok then
+    vim.notify("snacks.nvim not found", vim.log.levels.ERROR)
+    return
+  end
+
+  local opts = self:setup()
+  local picker_instance = nil
+
+  -- Start search if not already running
+  if SearchJob:status() == nil then
+    SearchJob:start()
+  end
+
+  -- Custom finder function that provides items and handles updates
+  local function finder_fn(_picker_ctx)
+    -- Get current environments
+    local envs = (SearchJob:status() == "dead") and get_envs() or SearchJob._temp_envs
+
+    -- Convert to snacks items format
+    local items = {}
+    for _, env in ipairs(envs) do
+      table.insert(items, {
+        text = tostring(env),
+        env = env,
+      })
+    end
+
+    return items
+  end
+
+  -- Create picker configuration with finder function
+  local picker_opts = vim.tbl_deep_extend("force", opts, {
+    finder = finder_fn,
+    confirm = function(picker, item)
+      picker:close()
+      if item and item.env then
+        handle_select(item.env)
+      end
+    end,
+  })
+
+  -- Show the picker
+  picker_instance = snacks.picker.pick(picker_opts)
+
+  -- If search is still running, hook into updates
+  if SearchJob:status() ~= "dead" then
+    SearchJob:update_hook(function(_)
+      -- Refresh the picker with new results
+      vim.schedule(function()
+        if picker_instance and picker_instance.refresh then
+          picker_instance:refresh()
+        elseif picker_instance and picker_instance.find then
+          picker_instance:find({ refresh = true })
+        end
+      end)
+    end, nil)
+  end
+end
+
+---@type WhichPy.Picker
+return Picker

--- a/lua/whichpy/picker/snacks.lua
+++ b/lua/whichpy/picker/snacks.lua
@@ -6,18 +6,14 @@ local get_envs = require("whichpy.envs").get_envs
 local Picker = {}
 
 function Picker:setup()
-  return vim.tbl_deep_extend(
-    "force",
-    {
-      prompt = " ",
-      title = "Select Python Interpreter",
-      format = "text",
-      layout = {
-          hidden = { "preview" },
-      }
+  return vim.tbl_deep_extend("force", {
+    prompt = " ",
+    title = "Select Python Interpreter",
+    format = "text",
+    layout = {
+      hidden = { "preview" },
     },
-    config.picker["snacks"] or {}
-  )
+  }, config.picker["snacks"] or {})
 end
 
 function Picker:show()

--- a/lua/whichpy/search.lua
+++ b/lua/whichpy/search.lua
@@ -2,11 +2,16 @@
 ---@field locator_name string
 ---@field wait? boolean
 ---@field err? string
----@field co? thread
+---@field co? fun(): fun(): WhichPy.InterpreterInfo?
 
 local util = require("whichpy.util")
 local locators = require("whichpy.locator").locators
 
+---@class WhichPy.SearchJob
+---@field co thread?
+---@field _temp_envs WhichPy.InterpreterInfo[]
+---@field on_result fun(info: WhichPy.InterpreterInfo)
+---@field on_finish fun()
 local SearchJob = {
   co = nil,
   _temp_envs = {},
@@ -36,6 +41,7 @@ function SearchJob:start()
         if ctx.wait then
           wait_group[ctx.locator_name] = true
         else
+          ---@cast ctx WhichPy.InterpreterInfo
           table.insert(self._temp_envs, ctx)
           if self.on_result then
             self.on_result(ctx)
@@ -70,6 +76,8 @@ function SearchJob:start()
   end)()
 end
 
+---@param on_result? fun(info: WhichPy.InterpreterInfo)
+---@param on_finish? fun()
 function SearchJob:update_hook(on_result, on_finish)
   self.on_result = on_result or function(_) end
   self.on_finish = on_finish or function() end

--- a/lua/whichpy/search.lua
+++ b/lua/whichpy/search.lua
@@ -20,7 +20,7 @@ function SearchJob:status()
 end
 
 function SearchJob:start()
-  if self.co ~= nil and self.status(self) ~= "dead" then
+  if self.co ~= nil and self:status() ~= "dead" then
     return
   end
 

--- a/lua/whichpy/usercmd.lua
+++ b/lua/whichpy/usercmd.lua
@@ -57,6 +57,15 @@ local subcommand_tbl = {
       end
     end,
   },
+  selectcwd = {
+    impl = function(opts)
+      if #opts.fargs > 1 then
+        vim.notify("Too many arguments", vim.log.levels.ERROR)
+      else
+        require("whichpy.envs").retrieve_cache()
+      end
+    end,
+  },
 }
 
 local function main_cmd(opts)

--- a/lua/whichpy/usercmd.lua
+++ b/lua/whichpy/usercmd.lua
@@ -23,6 +23,10 @@ local subcommand_tbl = {
       end
     end,
     complete = function(subcmd_arg_lead)
+      local SearchJob = require("whichpy.search")
+      if SearchJob:status() == nil then
+        SearchJob:start()
+      end
       local envs = require("whichpy.envs").get_envs()
       if #envs == 0 then
         return {}
@@ -30,7 +34,7 @@ local subcommand_tbl = {
       envs = vim
         .iter(envs)
         :map(function(env)
-          return env.interpreter_path
+          return env.path
         end)
         :filter(function(env)
           return env:find(subcmd_arg_lead)

--- a/lua/whichpy/usercmd.lua
+++ b/lua/whichpy/usercmd.lua
@@ -15,8 +15,12 @@ local subcommand_tbl = {
         if not vim.uv.fs_stat(python_path) then
           util.notify(python_path .. " doesn't exist.")
         else
+          local locator = require("whichpy.locator").get_locator("global")
+          if not locator then
+            return
+          end
           require("whichpy.envs").handle_select(InterpreterInfo:new({
-            locator = require("whichpy.locator").get_locator("global"),
+            locator = locator,
             path = python_path,
           }))
         end

--- a/lua/whichpy/usercmd.lua
+++ b/lua/whichpy/usercmd.lua
@@ -65,6 +65,15 @@ local subcommand_tbl = {
       end
     end,
   },
+  selectcwd = {
+    impl = function(opts)
+      if #opts.fargs > 1 then
+        vim.notify("Too many arguments", vim.log.levels.ERROR)
+      else
+        require("whichpy.envs").retrieve_cache()
+      end
+    end,
+  },
 }
 
 local function main_cmd(opts)

--- a/lua/whichpy/usercmd.lua
+++ b/lua/whichpy/usercmd.lua
@@ -79,6 +79,7 @@ local function main_cmd(opts)
   local subcommand = subcommand_tbl[subcommand_key]
   if not subcommand then
     vim.notify("WhichPy: Unknown command: " .. subcommand_key, vim.log.levels.ERROR)
+    return
   end
 
   subcommand.impl(opts)

--- a/lua/whichpy/usercmd.lua
+++ b/lua/whichpy/usercmd.lua
@@ -70,6 +70,7 @@ local function main_cmd(opts)
   local subcommand = subcommand_tbl[subcommand_key]
   if not subcommand then
     vim.notify("WhichPy: Unknown command: " .. subcommand_key, vim.log.levels.ERROR)
+    return
   end
 
   subcommand.impl(opts)

--- a/lua/whichpy/usercmd.lua
+++ b/lua/whichpy/usercmd.lua
@@ -13,7 +13,7 @@ local subcommand_tbl = {
       else
         local python_path = opts.fargs[2]
         if not vim.uv.fs_stat(python_path) then
-          util.notify(python_path .. " doesn't exists.")
+          util.notify(python_path .. " doesn't exist.")
         else
           require("whichpy.envs").handle_select(InterpreterInfo:new({
             locator = require("whichpy.locator").get_locator("global"),

--- a/lua/whichpy/util.lua
+++ b/lua/whichpy/util.lua
@@ -46,7 +46,7 @@ M.get_interpreter_path = function(dir, case)
   return vim.fs.joinpath(dir, case == "root" and "" or M.bin_scripts, M.filename)
 end
 
----@param plugin "fzf-lua"|"telescope"
+---@param plugin "fzf-lua"|"telescope"|"snacks"
 M.is_support = function(plugin)
   return pcall(require, plugin)
 end

--- a/lua/whichpy/util.lua
+++ b/lua/whichpy/util.lua
@@ -27,6 +27,9 @@ M.notify = function(msg, opts)
   notify_func(msg, level, opts)
 end
 
+---@generic T
+---@param tbl T[]
+---@return T[]
 M.deduplicate = function(tbl)
   local hash = {}
   local unique_tbl = {}
@@ -47,6 +50,7 @@ M.get_interpreter_path = function(dir, case)
 end
 
 ---@param plugin "fzf-lua"|"telescope"|"snacks"
+---@return boolean
 M.is_support = function(plugin)
   return pcall(require, plugin)
 end

--- a/lua/whichpy/util.lua
+++ b/lua/whichpy/util.lua
@@ -20,7 +20,7 @@ M.notify = function(msg, opts)
     notify_func = vim.notify_once
     opts.once = nil
   end
-  if not opts.level then
+  if opts.level then
     level = opts.level
     opts.level = nil
   end

--- a/tests/cache_spec.lua
+++ b/tests/cache_spec.lua
@@ -1,0 +1,82 @@
+---@diagnostic disable: undefined-field, duplicate-set-field
+local stub = require("luassert.stub")
+
+describe("cache", function()
+  local cache
+  local tmp_dir
+
+  before_each(function()
+    tmp_dir = vim.fn.tempname()
+    vim.fn.mkdir(tmp_dir, "p")
+    package.loaded["whichpy.cache"] = nil
+    cache = require("whichpy.cache")
+  end)
+
+  after_each(function()
+    vim.fn.delete(tmp_dir, "rf")
+  end)
+
+  describe("save and load", function()
+    it("should round-trip interpreter path and locator name", function()
+      cache.save(tmp_dir, "/usr/bin/python3", "global")
+      local path, locator_name = cache.load(tmp_dir)
+      assert.are.equal("/usr/bin/python3", path)
+      assert.are.equal("global", locator_name)
+    end)
+
+    it("should return nil when no cache exists", function()
+      local path, locator_name = cache.load(tmp_dir)
+      assert.is_nil(path)
+      assert.is_nil(locator_name)
+    end)
+
+    it("should overwrite previous cache", function()
+      cache.save(tmp_dir, "/usr/bin/python3", "global")
+      cache.save(tmp_dir, "/home/user/.venv/bin/python", "workspace")
+      local path, locator_name = cache.load(tmp_dir)
+      assert.are.equal("/home/user/.venv/bin/python", path)
+      assert.are.equal("workspace", locator_name)
+    end)
+
+    it("should create cache_dir if it does not exist", function()
+      local nested = vim.fs.joinpath(tmp_dir, "a", "b", "c")
+      cache.save(nested, "/usr/bin/python3", "global")
+      local path, locator_name = cache.load(nested)
+      assert.are.equal("/usr/bin/python3", path)
+      assert.are.equal("global", locator_name)
+    end)
+  end)
+
+  describe("remove", function()
+    it("should remove existing cache", function()
+      cache.save(tmp_dir, "/usr/bin/python3", "global")
+      cache.remove(tmp_dir)
+      local path, locator_name = cache.load(tmp_dir)
+      assert.is_nil(path)
+      assert.is_nil(locator_name)
+    end)
+
+    it("should not error when no cache exists", function()
+      assert.has_no.errors(function()
+        cache.remove(tmp_dir)
+      end)
+    end)
+  end)
+
+  describe("save error handling", function()
+    it("should notify on write failure", function()
+      local notify = stub(require("whichpy.util"), "notify")
+      local orig_open = io.open
+      io.open = function(_, _)
+        return nil, "mock error"
+      end
+      cache.save(tmp_dir, "/usr/bin/python3", "global")
+      io.open = orig_open
+      assert.spy(notify).was.called(1)
+      assert
+        .spy(notify).was
+        .called_with("Failed to write cache: mock error", { level = vim.log.levels.WARN })
+      notify:revert()
+    end)
+  end)
+end)

--- a/tests/envs_spec.lua
+++ b/tests/envs_spec.lua
@@ -1,0 +1,234 @@
+---@diagnostic disable: undefined-field
+local mock = require("luassert.mock")
+local stub = require("luassert.stub")
+local match = require("luassert.match")
+
+local function new_fake_handler()
+  local handler = {}
+  function handler:snapshot_settings(_) end
+  function handler:restore_snapshot(_) end
+  function handler:set_python_path(_, _) end
+  return handler
+end
+
+local function make_selected(path, env_var)
+  env_var = env_var or {}
+  return {
+    path = path,
+    locator_name = "test",
+    env_var = env_var,
+  }
+end
+
+describe("envs", function()
+  local envs
+  local handler1
+  local saved_virtual_env, saved_conda_prefix, saved_path
+
+  before_each(function()
+    saved_virtual_env = vim.env.VIRTUAL_ENV
+    saved_conda_prefix = vim.env.CONDA_PREFIX
+    saved_path = vim.env.PATH
+
+    handler1 = mock(new_fake_handler())
+
+    package.loaded["whichpy.envs"] = nil
+    package.loaded["whichpy.cache"] = nil
+
+    require("whichpy.config").config = {
+      update_path_env = false,
+      lsp = { srv1 = handler1 },
+      locator = {},
+      cache_dir = vim.fn.tempname(),
+      after_handle_select = nil,
+    }
+
+    stub(vim.lsp, "get_clients", function(opts)
+      if opts.name == "srv1" then
+        return { { name = "srv1", id = 1 } }
+      end
+      return {}
+    end)
+
+    envs = require("whichpy.envs")
+  end)
+
+  after_each(function()
+    vim.env.VIRTUAL_ENV = saved_virtual_env
+    vim.env.CONDA_PREFIX = saved_conda_prefix
+    vim.env.PATH = saved_path
+
+    mock.revert(handler1)
+    vim.lsp.get_clients:revert()
+
+    vim.fn.delete(require("whichpy.config").config.cache_dir, "rf")
+  end)
+
+  describe("handle_select", function()
+    it("should set current_selected to the selected path", function()
+      envs.handle_select(make_selected("/usr/bin/python3"), false)
+      assert.are.equal("/usr/bin/python3", envs.current_selected())
+    end)
+
+    it("should snapshot LSP on first select only", function()
+      envs.handle_select(make_selected("/usr/bin/python3"), false)
+      assert.spy(handler1.snapshot_settings).was.called(1)
+      assert.spy(handler1.set_python_path).was.called(1)
+
+      envs.handle_select(make_selected("/other/python"), false)
+      assert.spy(handler1.snapshot_settings).was.called(1)
+      assert.spy(handler1.set_python_path).was.called(2)
+    end)
+
+    it("should set VIRTUAL_ENV when env_var is VIRTUAL_ENV", function()
+      envs.handle_select(
+        make_selected("/home/.venv/bin/python", { name = "VIRTUAL_ENV", val = "/home/.venv" }),
+        false
+      )
+      assert.are.equal("/home/.venv", vim.env.VIRTUAL_ENV)
+      assert.is_nil(vim.env.CONDA_PREFIX)
+    end)
+
+    it("should set CONDA_PREFIX when env_var is CONDA_PREFIX", function()
+      envs.handle_select(
+        make_selected(
+          "/opt/conda/envs/myenv/bin/python",
+          { name = "CONDA_PREFIX", val = "/opt/conda/envs/myenv" }
+        ),
+        false
+      )
+      assert.is_nil(vim.env.VIRTUAL_ENV)
+      assert.are.equal("/opt/conda/envs/myenv", vim.env.CONDA_PREFIX)
+    end)
+
+    it("should clear both env vars when env_var has no name", function()
+      vim.env.VIRTUAL_ENV = "/old"
+      vim.env.CONDA_PREFIX = "/old"
+      envs.handle_select(make_selected("/usr/bin/python3", {}), false)
+      assert.is_nil(vim.env.VIRTUAL_ENV)
+      assert.is_nil(vim.env.CONDA_PREFIX)
+    end)
+
+    it("should call after_handle_select callback", function()
+      local called_with = nil
+      require("whichpy.config").config.after_handle_select = function(selected)
+        called_with = selected
+      end
+      local sel = make_selected("/usr/bin/python3")
+      envs.handle_select(sel, false)
+      assert.are.equal(sel, called_with)
+    end)
+
+    it("should write cache when should_cache is true", function()
+      local cache = require("whichpy.cache")
+      local save = stub(cache, "save")
+      envs.handle_select(make_selected("/usr/bin/python3"), true)
+      assert.spy(save).was.called(1)
+      save:revert()
+    end)
+
+    it("should not write cache when should_cache is false", function()
+      local cache = require("whichpy.cache")
+      local save = stub(cache, "save")
+      envs.handle_select(make_selected("/usr/bin/python3"), false)
+      assert.spy(save).was.called(0)
+      save:revert()
+    end)
+  end)
+
+  describe("handle_select with update_path_env", function()
+    it("should prepend to PATH on first select", function()
+      require("whichpy.config").config.update_path_env = true
+      local orig_path = vim.env.PATH
+      envs.handle_select(make_selected("/home/.venv/bin/python", {}), false)
+      assert.is_truthy(vim.env.PATH:find("/home/.venv/bin:", 1, true))
+      vim.env.PATH = orig_path
+    end)
+
+    it("should replace previous path on subsequent select", function()
+      require("whichpy.config").config.update_path_env = true
+      local orig_path = vim.env.PATH
+      envs.handle_select(make_selected("/first/bin/python", {}), false)
+      envs.handle_select(make_selected("/second/bin/python", {}), false)
+      assert.is_falsy(vim.env.PATH:find("/first/bin:", 1, true))
+      assert.is_truthy(vim.env.PATH:find("/second/bin:", 1, true))
+      vim.env.PATH = orig_path
+    end)
+  end)
+
+  describe("handle_reset", function()
+    it("should do nothing if no select was made", function()
+      envs.handle_reset()
+      assert.spy(handler1.restore_snapshot).was.called(0)
+    end)
+
+    it("should restore LSP snapshot", function()
+      envs.handle_select(make_selected("/usr/bin/python3"), false)
+      envs.handle_reset()
+      assert.spy(handler1.restore_snapshot).was.called(1)
+    end)
+
+    it("should restore env vars to original values", function()
+      vim.env.VIRTUAL_ENV = "/original/venv"
+      vim.env.CONDA_PREFIX = nil
+
+      -- Reload to capture original env vars in backup
+      package.loaded["whichpy.envs"] = nil
+      envs = require("whichpy.envs")
+
+      envs.handle_select(
+        make_selected("/new/bin/python", { name = "CONDA_PREFIX", val = "/new/conda" }),
+        false
+      )
+      assert.are.equal("/new/conda", vim.env.CONDA_PREFIX)
+      assert.is_nil(vim.env.VIRTUAL_ENV)
+
+      envs.handle_reset()
+      assert.are.equal("/original/venv", vim.env.VIRTUAL_ENV)
+      assert.is_nil(vim.env.CONDA_PREFIX)
+    end)
+
+    it("should clear current_selected after reset", function()
+      envs.handle_select(make_selected("/usr/bin/python3"), false)
+      assert.is_not_nil(envs.current_selected())
+      envs.handle_reset()
+      assert.is_nil(envs.current_selected())
+    end)
+
+    it("should remove cache on reset", function()
+      local cache = require("whichpy.cache")
+      local remove = stub(cache, "remove")
+      envs.handle_select(make_selected("/usr/bin/python3"), false)
+      envs.handle_reset()
+      assert.spy(remove).was.called(1)
+      remove:revert()
+    end)
+
+    it("should restore PATH on reset when update_path_env is true", function()
+      require("whichpy.config").config.update_path_env = true
+      local orig_path = vim.env.PATH
+      envs.handle_select(make_selected("/home/.venv/bin/python", {}), false)
+      envs.handle_reset()
+      assert.are.equal(orig_path, vim.env.PATH)
+    end)
+  end)
+
+  describe("current_selected_name", function()
+    it("should return env_var val after select", function()
+      envs.handle_select(
+        make_selected("/home/.venv/bin/python", { name = "VIRTUAL_ENV", val = "/home/.venv" }),
+        false
+      )
+      assert.are.equal("/home/.venv", envs.current_selected_name())
+    end)
+
+    it("should return nil after reset", function()
+      envs.handle_select(
+        make_selected("/home/.venv/bin/python", { name = "VIRTUAL_ENV", val = "/home/.venv" }),
+        false
+      )
+      envs.handle_reset()
+      assert.is_nil(envs.current_selected_name())
+    end)
+  end)
+end)

--- a/tests/helpers/mock_fs.lua
+++ b/tests/helpers/mock_fs.lua
@@ -1,0 +1,137 @@
+local stub = require("luassert.stub")
+
+local M = {}
+
+-- Flattened file system: { ["/a/b/c"] = "file", ["/a/b"] = "directory", ... }
+local _flat = {}
+local _stubs = {}
+
+--- Flatten a nested tree into absolute paths.
+---@param tree table
+local function flatten(tree)
+  local result = {}
+  for abs_path, children in pairs(tree) do
+    result[abs_path] = "directory"
+    local function walk(dir, node)
+      for name, val in pairs(node) do
+        local full = vim.fs.joinpath(dir, name)
+        if val == "file" then
+          result[full] = "file"
+        elseif type(val) == "table" then
+          result[full] = "directory"
+          walk(full, val)
+        end
+      end
+    end
+    walk(abs_path, children)
+  end
+  return result
+end
+
+--- Remove trailing slash from path (keep root "/" as-is).
+---@param path string
+---@return string
+local function normalize(path)
+  if #path > 1 and path:sub(-1) == "/" then
+    return path:sub(1, -2)
+  end
+  return path
+end
+
+--- Get immediate children of a directory path.
+--- Expects a normalized path (no trailing slash, except root "/").
+---@param dir string
+---@return {name: string, type: string}[]
+local function get_children(dir)
+  local children = {}
+  local prefix = dir == "/" and "/" or (dir .. "/")
+  for path, ftype in pairs(_flat) do
+    if vim.startswith(path, prefix) then
+      local rest = path:sub(#prefix + 1)
+      if not rest:find("/") then
+        children[#children + 1] = { name = rest, type = ftype }
+      end
+    end
+  end
+  table.sort(children, function(a, b)
+    return a.name < b.name
+  end)
+  return children
+end
+
+--- Install mock filesystem stubs.
+---@param tree table Nested table: key=absolute path, value=table (dir) or "file"
+function M.setup(tree)
+  _flat = flatten(tree)
+
+  -- vim.uv.fs_scandir
+  _stubs[#_stubs + 1] = stub(vim.uv, "fs_scandir", function(path)
+    local norm = normalize(path)
+    if _flat[norm] ~= "directory" then
+      return nil
+    end
+    return { entries = get_children(norm), cursor = 1 }
+  end)
+
+  -- vim.uv.fs_scandir_next
+  _stubs[#_stubs + 1] = stub(vim.uv, "fs_scandir_next", function(state)
+    if state == nil or state.cursor > #state.entries then
+      return nil
+    end
+    local entry = state.entries[state.cursor]
+    state.cursor = state.cursor + 1
+    return entry.name, entry.type
+  end)
+
+  -- vim.uv.fs_stat
+  _stubs[#_stubs + 1] = stub(vim.uv, "fs_stat", function(path)
+    local ftype = _flat[normalize(path)]
+    if ftype then
+      return { type = ftype }
+    end
+    return nil
+  end)
+
+  -- vim.fs.dir
+  _stubs[#_stubs + 1] = stub(vim.fs, "dir", function(path)
+    local children = get_children(normalize(path))
+    local i = 0
+    return function()
+      i = i + 1
+      if i > #children then
+        return nil
+      end
+      return children[i].name, children[i].type
+    end
+  end)
+end
+
+--- Revert all stubs.
+function M.teardown()
+  for _, s in ipairs(_stubs) do
+    s:revert()
+  end
+  _stubs = {}
+  _flat = {}
+end
+
+--- Reload locator modules so they pick up fresh config and stubs.
+--- Call AFTER setting up config and any stubs on _common.
+---@param modules string[] Module names to reload (e.g., {"workspace", "global"})
+function M.reload_locator_modules(modules)
+  package.loaded["whichpy.locator._common"] = nil
+  for _, name in ipairs(modules) do
+    package.loaded["whichpy.locator." .. name] = nil
+  end
+end
+
+--- Initialize minimal config needed for tests.
+function M.init_config()
+  require("whichpy.config").config = {
+    update_path_env = false,
+    lsp = {},
+    locator = {},
+  }
+end
+
+return M

--- a/tests/helpers/test_utils.lua
+++ b/tests/helpers/test_utils.lua
@@ -1,0 +1,46 @@
+local M = {}
+
+--- Consume an iterator and collect all results into a table.
+---@param iter function
+---@return table[]
+function M.collect(iter)
+  local results = {}
+  for info in iter do
+    results[#results + 1] = info
+  end
+  return results
+end
+
+--- Create a fake job with `continued_with` state tracking.
+---@return table
+function M.make_fake_job()
+  local job = { continued_with = nil }
+  function job:continue(ctx)
+    self.continued_with = ctx
+  end
+  return job
+end
+
+--- Create a no-op fake job (continue does nothing).
+---@return table
+function M.make_noop_job()
+  local job = {}
+  function job:continue(_) end
+  return job
+end
+
+--- Create a fake locator mock with the given name and display_name.
+---@param name string
+---@param display_name string
+---@return table
+function M.make_fake_locator(name, display_name)
+  return {
+    name = name,
+    display_name = display_name,
+    get_env_var_strategy = function()
+      return {}
+    end,
+  }
+end
+
+return M

--- a/tests/locator/async_spec.lua
+++ b/tests/locator/async_spec.lua
@@ -1,0 +1,256 @@
+local stub = require("luassert.stub")
+local mock_fs = require("tests.helpers.mock_fs")
+local test_utils = require("tests.helpers.test_utils")
+
+describe("async_find coroutine protocol", function()
+  local common
+  local executable_stub, system_stub
+
+  before_each(function()
+    mock_fs.init_config()
+    mock_fs.reload_locator_modules({})
+    common = require("whichpy.locator._common")
+
+    executable_stub = stub(vim.fn, "executable")
+    system_stub = stub(vim, "system")
+  end)
+
+  after_each(function()
+    executable_stub:revert()
+    system_stub:revert()
+    mock_fs.teardown()
+  end)
+
+  local make_fake_job = test_utils.make_fake_job
+  local fake_locator = test_utils.make_fake_locator("test_async", "Test Async")
+
+  it("should return immediately when executable not found", function()
+    executable_stub.returns(0)
+
+    local iter = common.async_find({
+      locator = fake_locator,
+      Job = make_fake_job(),
+      cmd = { "notfound", "arg" },
+      parse_output = function(stdout)
+        return vim.trim(stdout)
+      end,
+      err_msg = "test error",
+      find_fn = common.find_interpreters_in_dir,
+    })
+
+    local result = iter()
+    assert.is_nil(result)
+    assert.spy(system_stub).was.called(0)
+  end)
+
+  it("should yield wait marker and call vim.system", function()
+    executable_stub.returns(1)
+    local captured_callback
+
+    system_stub.invokes(function(_, _, cb)
+      captured_callback = cb
+    end)
+
+    local Job = make_fake_job()
+    local iter = common.async_find({
+      locator = fake_locator,
+      Job = Job,
+      cmd = { "mycmd", "arg" },
+      parse_output = function(stdout)
+        return vim.trim(stdout)
+      end,
+      err_msg = "test error",
+      find_fn = common.find_interpreters_in_dir,
+    })
+
+    local result = iter()
+    assert.are.same({ locator_name = "test_async", wait = true }, result)
+    assert.is_not_nil(captured_callback)
+  end)
+
+  it("should set err in ctx when command fails", function()
+    executable_stub.returns(1)
+    local captured_callback
+
+    system_stub.invokes(function(_, _, cb)
+      captured_callback = cb
+    end)
+
+    local Job = make_fake_job()
+    local iter = common.async_find({
+      locator = fake_locator,
+      Job = Job,
+      cmd = { "mycmd" },
+      parse_output = function(stdout)
+        return vim.trim(stdout)
+      end,
+      err_msg = "test error",
+      find_fn = common.find_interpreters_in_dir,
+    })
+
+    iter() -- consume wait marker
+    captured_callback({ code = 1, stdout = "", stderr = "fail" })
+
+    assert.are.equal("test error", Job.continued_with.err)
+  end)
+
+  it("should set co in ctx when command succeeds", function()
+    executable_stub.returns(1)
+    local captured_callback
+
+    system_stub.invokes(function(_, _, cb)
+      captured_callback = cb
+    end)
+
+    mock_fs.setup({
+      ["/venvs"] = {
+        myenv = { bin = { python = "file" } },
+      },
+    })
+
+    local Job = make_fake_job()
+    local iter = common.async_find({
+      locator = fake_locator,
+      Job = Job,
+      cmd = { "mycmd" },
+      parse_output = function(stdout)
+        return vim.trim(stdout)
+      end,
+      err_msg = "test error",
+      find_fn = common.find_interpreters_in_dir,
+    })
+
+    iter() -- consume wait marker
+    captured_callback({ code = 0, stdout = "/venvs\n", stderr = "" })
+
+    assert.is_not_nil(Job.continued_with.co)
+    assert.is_nil(Job.continued_with.err)
+  end)
+
+  it("should not set co when parse_output returns nil", function()
+    executable_stub.returns(1)
+    local captured_callback
+
+    system_stub.invokes(function(_, _, cb)
+      captured_callback = cb
+    end)
+
+    local Job = make_fake_job()
+    local iter = common.async_find({
+      locator = fake_locator,
+      Job = Job,
+      cmd = { "mycmd" },
+      parse_output = function(_)
+        return nil
+      end,
+      err_msg = "test error",
+      find_fn = common.find_interpreters_in_dir,
+    })
+
+    iter()
+    captured_callback({ code = 0, stdout = "bad output", stderr = "" })
+
+    assert.is_nil(Job.continued_with.co)
+    assert.is_nil(Job.continued_with.err)
+  end)
+end)
+
+describe("async locator configurations", function()
+  local executable_stub, system_stub
+
+  before_each(function()
+    mock_fs.init_config()
+    mock_fs.reload_locator_modules({ "poetry", "pdm", "uv", "conda" })
+
+    executable_stub = stub(vim.fn, "executable", 1)
+    system_stub = stub(vim, "system")
+    ---@diagnostic disable-next-line: undefined-field
+    system_stub.invokes(function(_, _, _) end)
+  end)
+
+  after_each(function()
+    executable_stub:revert()
+    system_stub:revert()
+    mock_fs.teardown()
+  end)
+
+  it("poetry should use correct command", function()
+    local Locator = require("whichpy.locator.poetry")
+    local locator = Locator.new()
+    local iter = locator:find(test_utils.make_noop_job())
+    iter() -- trigger vim.system
+
+    assert.spy(system_stub).was.called(1)
+    local call_args = system_stub.calls[1].refs
+    assert.are.same({ "poetry", "config", "virtualenvs.path" }, call_args[1])
+  end)
+
+  it("pdm should use correct command", function()
+    local Locator = require("whichpy.locator.pdm")
+    local locator = Locator.new()
+    local iter = locator:find(test_utils.make_noop_job())
+    iter()
+
+    assert.spy(system_stub).was.called(1)
+    local call_args = system_stub.calls[1].refs
+    assert.are.same({ "pdm", "config", "venv.location" }, call_args[1])
+  end)
+
+  it("uv should use correct command", function()
+    local Locator = require("whichpy.locator.uv")
+    local locator = Locator.new()
+    local iter = locator:find(test_utils.make_noop_job())
+    iter()
+
+    assert.spy(system_stub).was.called(1)
+    local call_args = system_stub.calls[1].refs
+    assert.are.same({ "uv", "python", "dir" }, call_args[1])
+  end)
+
+  it("conda should use correct command", function()
+    local Locator = require("whichpy.locator.conda")
+    local locator = Locator.new()
+    local iter = locator:find(test_utils.make_noop_job())
+    iter()
+
+    assert.spy(system_stub).was.called(1)
+    local call_args = system_stub.calls[1].refs
+    assert.are.same({ "conda", "info", "--json" }, call_args[1])
+  end)
+
+  it("conda should parse JSON envs correctly", function()
+    local captured_callback
+
+    system_stub.invokes(function(_, _, cb)
+      captured_callback = cb
+    end)
+
+    mock_fs.setup({
+      ["/opt/conda/envs/myenv"] = {
+        bin = { python = "file" },
+      },
+    })
+
+    local Locator = require("whichpy.locator.conda")
+    local locator = Locator.new()
+    local job = test_utils.make_fake_job()
+
+    local iter = locator:find(job)
+    iter()
+
+    captured_callback({
+      code = 0,
+      stdout = vim.json.encode({ envs = { "/opt/conda/envs/myenv" } }),
+      stderr = "",
+    })
+
+    assert.is_not_nil(job.continued_with.co)
+
+    local results = {}
+    for info in job.continued_with.co() do
+      results[#results + 1] = info
+    end
+    assert.are.equal(1, #results)
+    assert.is_truthy(results[1].path:find("myenv/bin/python"))
+  end)
+end)

--- a/tests/locator/common_spec.lua
+++ b/tests/locator/common_spec.lua
@@ -139,6 +139,12 @@ describe("_common find_interpreters_in_dir", function()
     assert.are.equal(0, #results)
   end)
 
+  it("should return empty for non-existent directory", function()
+    mock_fs.setup({})
+    local results = collect(common.find_interpreters_in_dir(fake_locator, "/nonexistent"))
+    assert.are.equal(0, #results)
+  end)
+
   it("should skip subdirectories without python binary", function()
     mock_fs.setup({
       ["/venvs"] = {

--- a/tests/locator/common_spec.lua
+++ b/tests/locator/common_spec.lua
@@ -1,0 +1,154 @@
+local mock_fs = require("tests.helpers.mock_fs")
+local test_utils = require("tests.helpers.test_utils")
+local collect = test_utils.collect
+
+describe("_common env_var_strategy", function()
+  local common
+
+  before_each(function()
+    mock_fs.init_config()
+    mock_fs.reload_locator_modules({})
+    common = require("whichpy.locator._common")
+  end)
+
+  after_each(function()
+    mock_fs.teardown()
+  end)
+
+  describe("virtual_env", function()
+    it("should return VIRTUAL_ENV as parent of parent", function()
+      local result = common.get_env_var_strategy.virtual_env("/home/user/.venv/bin/python")
+      assert.are.same({ name = "VIRTUAL_ENV", val = "/home/user/.venv" }, result)
+    end)
+  end)
+
+  describe("conda", function()
+    it("should return CONDA_PREFIX as grandparent on unix", function()
+      local result = common.get_env_var_strategy.conda("/opt/conda/envs/myenv/bin/python")
+      assert.are.same({ name = "CONDA_PREFIX", val = "/opt/conda/envs/myenv" }, result)
+    end)
+  end)
+
+  describe("pyenv", function()
+    it("should return VIRTUAL_ENV when pyvenv.cfg exists", function()
+      mock_fs.setup({
+        ["/home/user/.pyenv/versions/3.11.0/envs/myenv"] = {
+          bin = { python = "file" },
+          ["pyvenv.cfg"] = "file",
+        },
+      })
+
+      local result =
+        common.get_env_var_strategy.pyenv("/home/user/.pyenv/versions/3.11.0/envs/myenv/bin/python")
+      assert.are.same(
+        { name = "VIRTUAL_ENV", val = "/home/user/.pyenv/versions/3.11.0/envs/myenv" },
+        result
+      )
+    end)
+
+    it("should return empty table when pyvenv.cfg does not exist", function()
+      mock_fs.setup({
+        ["/home/user/.pyenv/versions/3.11.0"] = {
+          bin = { python = "file" },
+        },
+      })
+
+      local result =
+        common.get_env_var_strategy.pyenv("/home/user/.pyenv/versions/3.11.0/bin/python")
+      assert.are.same({}, result)
+    end)
+  end)
+
+  describe("guess", function()
+    it("should detect conda-meta and return CONDA_PREFIX", function()
+      mock_fs.setup({
+        ["/opt/conda/envs/myenv"] = {
+          bin = { python = "file" },
+          ["conda-meta"] = {},
+        },
+      })
+
+      local result = common.get_env_var_strategy.guess("/opt/conda/envs/myenv/bin/python")
+      assert.are.same({ name = "CONDA_PREFIX", val = "/opt/conda/envs/myenv" }, result)
+    end)
+
+    it("should detect pyvenv.cfg and return VIRTUAL_ENV", function()
+      mock_fs.setup({
+        ["/home/user/project/.venv"] = {
+          bin = { python = "file" },
+          ["pyvenv.cfg"] = "file",
+        },
+      })
+
+      local result = common.get_env_var_strategy.guess("/home/user/project/.venv/bin/python")
+      assert.are.same({ name = "VIRTUAL_ENV", val = "/home/user/project/.venv" }, result)
+    end)
+
+    it("should return empty table when no markers found", function()
+      mock_fs.setup({
+        ["/usr/local"] = {
+          bin = { python = "file" },
+        },
+      })
+
+      local result = common.get_env_var_strategy.guess("/usr/local/bin/python")
+      assert.are.same({}, result)
+    end)
+  end)
+
+  describe("no", function()
+    it("should return empty table", function()
+      assert.are.same({}, common.get_env_var_strategy.no())
+    end)
+  end)
+end)
+
+describe("_common find_interpreters_in_dir", function()
+  local common
+
+  before_each(function()
+    mock_fs.init_config()
+    mock_fs.reload_locator_modules({})
+    common = require("whichpy.locator._common")
+  end)
+
+  after_each(function()
+    mock_fs.teardown()
+  end)
+
+  local fake_locator = test_utils.make_fake_locator("test", "Test")
+
+  it("should yield interpreters from subdirectories", function()
+    mock_fs.setup({
+      ["/venvs"] = {
+        myenv = { bin = { python = "file" } },
+        other = { bin = { python = "file" } },
+      },
+    })
+
+    local results = collect(common.find_interpreters_in_dir(fake_locator, "/venvs"))
+    assert.are.equal(2, #results)
+  end)
+
+  it("should yield nothing for empty directory", function()
+    mock_fs.setup({
+      ["/venvs"] = {},
+    })
+
+    local results = collect(common.find_interpreters_in_dir(fake_locator, "/venvs"))
+    assert.are.equal(0, #results)
+  end)
+
+  it("should skip subdirectories without python binary", function()
+    mock_fs.setup({
+      ["/venvs"] = {
+        myenv = { bin = {} },
+        valid = { bin = { python = "file" } },
+      },
+    })
+
+    local results = collect(common.find_interpreters_in_dir(fake_locator, "/venvs"))
+    assert.are.equal(1, #results)
+    assert.is_truthy(results[1].path:find("valid/bin/python"))
+  end)
+end)

--- a/tests/locator/global_spec.lua
+++ b/tests/locator/global_spec.lua
@@ -1,0 +1,66 @@
+local stub = require("luassert.stub")
+local mock_fs = require("tests.helpers.mock_fs")
+local collect = require("tests.helpers.test_utils").collect
+
+describe("global locator", function()
+  local Locator, common
+  local get_search_path_stub
+
+  before_each(function()
+    mock_fs.init_config()
+    mock_fs.reload_locator_modules({ "global" })
+    common = require("whichpy.locator._common")
+  end)
+
+  after_each(function()
+    if get_search_path_stub then
+      get_search_path_stub:revert()
+    end
+    mock_fs.teardown()
+  end)
+
+  local function setup_with_stub(dirs)
+    get_search_path_stub = stub(common, "get_search_path_entries", function()
+      return dirs
+    end)
+    package.loaded["whichpy.locator.global"] = nil
+    Locator = require("whichpy.locator.global")
+  end
+
+  it("should find python in PATH directories", function()
+    setup_with_stub({ "/usr/bin/", "/usr/local/bin/" })
+
+    mock_fs.setup({
+      ["/usr/bin"] = { python = "file" },
+      ["/usr/local/bin"] = { python = "file" },
+    })
+
+    local locator = Locator.new()
+    local results = collect(locator:find())
+
+    assert.are.equal(2, #results)
+  end)
+
+  it("should skip directories without python", function()
+    setup_with_stub({ "/usr/bin/", "/empty/" })
+
+    mock_fs.setup({
+      ["/usr/bin"] = { python = "file" },
+      ["/empty"] = {},
+    })
+
+    local locator = Locator.new()
+    local results = collect(locator:find())
+
+    assert.are.equal(1, #results)
+  end)
+
+  it("should yield nothing for empty PATH", function()
+    setup_with_stub({})
+
+    local locator = Locator.new()
+    local results = collect(locator:find())
+
+    assert.are.equal(0, #results)
+  end)
+end)

--- a/tests/locator/global_venv_spec.lua
+++ b/tests/locator/global_venv_spec.lua
@@ -1,0 +1,70 @@
+local stub = require("luassert.stub")
+local mock_fs = require("tests.helpers.mock_fs")
+local collect = require("tests.helpers.test_utils").collect
+
+describe("global_virtual_environment locator", function()
+  local Locator, common
+
+  before_each(function()
+    mock_fs.init_config()
+    mock_fs.reload_locator_modules({ "global_virtual_environment" })
+    common = require("whichpy.locator._common")
+  end)
+
+  after_each(function()
+    if common.get_global_virtual_environment_dirs.revert then
+      common.get_global_virtual_environment_dirs:revert()
+    end
+    mock_fs.teardown()
+  end)
+
+  local function setup_with_stub(dirs)
+    stub(common, "get_global_virtual_environment_dirs", function()
+      return dirs
+    end)
+    package.loaded["whichpy.locator.global_virtual_environment"] = nil
+    Locator = require("whichpy.locator.global_virtual_environment")
+  end
+
+  it("should find venvs in global dirs", function()
+    setup_with_stub({ "/home/user/.venvs/" })
+
+    mock_fs.setup({
+      ["/home/user/.venvs"] = {
+        myproject = { bin = { python = "file" } },
+      },
+    })
+
+    local locator = Locator.new()
+    local results = collect(locator:find())
+
+    assert.are.equal(1, #results)
+    assert.is_truthy(results[1].path:find("myproject/bin/python"))
+  end)
+
+  it("should skip subdirectories without python binary", function()
+    setup_with_stub({ "/home/user/.venvs/" })
+
+    mock_fs.setup({
+      ["/home/user/.venvs"] = {
+        myproject = { bin = {} },
+        valid = { bin = { python = "file" } },
+      },
+    })
+
+    local locator = Locator.new()
+    local results = collect(locator:find())
+
+    assert.are.equal(1, #results)
+    assert.is_truthy(results[1].path:find("valid/bin/python"))
+  end)
+
+  it("should yield nothing for empty global dirs", function()
+    setup_with_stub({})
+
+    local locator = Locator.new()
+    local results = collect(locator:find())
+
+    assert.are.equal(0, #results)
+  end)
+end)

--- a/tests/locator/pyenv_spec.lua
+++ b/tests/locator/pyenv_spec.lua
@@ -1,0 +1,115 @@
+local stub = require("luassert.stub")
+local mock_fs = require("tests.helpers.mock_fs")
+local collect = require("tests.helpers.test_utils").collect
+
+describe("pyenv locator", function()
+  local Locator, common
+
+  before_each(function()
+    mock_fs.init_config()
+    mock_fs.reload_locator_modules({ "pyenv" })
+    common = require("whichpy.locator._common")
+
+    stub(common, "get_pyenv_version_dir", function()
+      return "/home/user/.pyenv/versions"
+    end)
+
+    package.loaded["whichpy.locator.pyenv"] = nil
+    Locator = require("whichpy.locator.pyenv")
+  end)
+
+  after_each(function()
+    common.get_pyenv_version_dir:revert()
+    mock_fs.teardown()
+  end)
+
+  it("should find envs/ venvs when venv_only=true", function()
+    mock_fs.setup({
+      ["/home/user/.pyenv/versions"] = {
+        ["3.11.0"] = {
+          bin = { python = "file" },
+          envs = {
+            myenv = { bin = { python = "file" } },
+          },
+        },
+      },
+    })
+
+    local locator = Locator.new({ venv_only = true })
+    local results = collect(locator:find())
+
+    assert.are.equal(1, #results)
+    assert.is_truthy(results[1].path:find("envs/myenv/bin/python"))
+  end)
+
+  it("should skip base interpreter when venv_only=true", function()
+    mock_fs.setup({
+      ["/home/user/.pyenv/versions"] = {
+        ["3.11.0"] = {
+          bin = { python = "file" },
+          envs = {},
+        },
+      },
+    })
+
+    local locator = Locator.new({ venv_only = true })
+    local results = collect(locator:find())
+
+    assert.are.equal(0, #results)
+  end)
+
+  it("should find base and venvs when venv_only=false", function()
+    mock_fs.setup({
+      ["/home/user/.pyenv/versions"] = {
+        ["3.11.0"] = {
+          bin = { python = "file" },
+          envs = {
+            myenv = { bin = { python = "file" } },
+          },
+        },
+      },
+    })
+
+    local locator = Locator.new({ venv_only = false })
+    local results = collect(locator:find())
+
+    assert.are.equal(2, #results)
+  end)
+
+  it("should handle multiple versions with multiple venvs", function()
+    mock_fs.setup({
+      ["/home/user/.pyenv/versions"] = {
+        ["3.11.0"] = {
+          bin = { python = "file" },
+          envs = {
+            env1 = { bin = { python = "file" } },
+          },
+        },
+        ["3.12.0"] = {
+          bin = { python = "file" },
+          envs = {
+            env2 = { bin = { python = "file" } },
+            env3 = { bin = { python = "file" } },
+          },
+        },
+      },
+    })
+
+    local locator = Locator.new({ venv_only = false })
+    local results = collect(locator:find())
+
+    -- 2 base + 3 venvs = 5
+    assert.are.equal(5, #results)
+  end)
+
+  it("should yield nothing when no versions exist", function()
+    mock_fs.setup({
+      ["/home/user/.pyenv/versions"] = {},
+    })
+
+    local locator = Locator.new()
+    local results = collect(locator:find())
+
+    assert.are.equal(0, #results)
+  end)
+end)

--- a/tests/locator/workspace_spec.lua
+++ b/tests/locator/workspace_spec.lua
@@ -1,0 +1,129 @@
+local stub = require("luassert.stub")
+local mock_fs = require("tests.helpers.mock_fs")
+local collect = require("tests.helpers.test_utils").collect
+
+describe("workspace locator", function()
+  local Locator, common
+  local get_workspace_folders_stub
+
+  before_each(function()
+    mock_fs.init_config()
+
+    -- Reload _common to pick up fresh config
+    mock_fs.reload_locator_modules({ "workspace" })
+    common = require("whichpy.locator._common")
+
+    -- Stub BEFORE reloading workspace so it captures the stubbed version
+    get_workspace_folders_stub = stub(common, "get_workspace_folders", function()
+      return { "/project" }
+    end)
+
+    -- Reload workspace to capture stubbed get_workspace_folders
+    package.loaded["whichpy.locator.workspace"] = nil
+    Locator = require("whichpy.locator.workspace")
+  end)
+
+  after_each(function()
+    get_workspace_folders_stub:revert()
+    mock_fs.teardown()
+  end)
+
+  it("should find .venv in workspace root", function()
+    mock_fs.setup({
+      ["/project"] = {
+        [".venv"] = { bin = { python = "file" } },
+      },
+    })
+
+    local locator = Locator.new()
+    local results = collect(locator:find())
+
+    assert.are.equal(1, #results)
+    assert.is_truthy(results[1].path:find("%.venv/bin/python"))
+  end)
+
+  it("should find multiple venvs", function()
+    mock_fs.setup({
+      ["/project"] = {
+        [".venv"] = { bin = { python = "file" } },
+        [".env"] = { bin = { python = "file" } },
+      },
+    })
+
+    local locator = Locator.new()
+    local results = collect(locator:find())
+
+    assert.are.equal(2, #results)
+  end)
+
+  it("should respect depth limit", function()
+    mock_fs.setup({
+      ["/project"] = {
+        sub1 = {
+          sub2 = {
+            [".venv"] = { bin = { python = "file" } },
+          },
+        },
+      },
+    })
+
+    local locator = Locator.new({ depth = 2 })
+    local results = collect(locator:find())
+
+    assert.are.equal(0, #results)
+  end)
+
+  it("should ignore .git, __pycache__ and other ignore_dirs", function()
+    mock_fs.setup({
+      ["/project"] = {
+        [".git"] = { env = { bin = { python = "file" } } },
+        __pycache__ = { env = { bin = { python = "file" } } },
+      },
+    })
+
+    local locator = Locator.new()
+    local results = collect(locator:find())
+
+    assert.are.equal(0, #results)
+  end)
+
+  it("should skip directories without python binary", function()
+    mock_fs.setup({
+      ["/project"] = {
+        [".venv"] = { bin = {} },
+      },
+    })
+
+    local locator = Locator.new()
+    local results = collect(locator:find())
+
+    assert.are.equal(0, #results)
+  end)
+
+  it("should find venvs in subdirectories within depth limit", function()
+    mock_fs.setup({
+      ["/project"] = {
+        subdir = {
+          [".env"] = { bin = { python = "file" } },
+        },
+      },
+    })
+
+    local locator = Locator.new({ depth = 2 })
+    local results = collect(locator:find())
+
+    assert.are.equal(1, #results)
+    assert.is_truthy(results[1].path:find("subdir/%.env/bin/python"))
+  end)
+
+  it("should yield nothing for empty workspace", function()
+    mock_fs.setup({
+      ["/project"] = {},
+    })
+
+    local locator = Locator.new()
+    local results = collect(locator:find())
+
+    assert.are.equal(0, #results)
+  end)
+end)

--- a/tests/lsp_attach_spec.lua
+++ b/tests/lsp_attach_spec.lua
@@ -117,7 +117,10 @@ describe("LSP attach behavior", function()
       assert.spy(retrieve_cache).was.called(0)
       assert.spy(lsp_handler1.snapshot_settings).was.called(1)
       assert.spy(lsp_handler1.set_python_path).was.called(2)
-      assert.are.same({ "snapshot_settings", "set_python_path", "set_python_path" }, lsp_handler1._call_order)
+      assert.are.same(
+        { "snapshot_settings", "set_python_path", "set_python_path" },
+        lsp_handler1._call_order
+      )
       current_selected:revert()
       retrieve_cache:revert()
     end)
@@ -153,8 +156,14 @@ describe("LSP attach behavior", function()
       assert.spy(lsp_handler2.snapshot_settings).was.called(1)
       assert.spy(lsp_handler1.set_python_path).was.called(2)
       assert.spy(lsp_handler2.set_python_path).was.called(2)
-      assert.are.same({ "snapshot_settings", "set_python_path", "set_python_path" }, lsp_handler1._call_order)
-      assert.are.same({ "snapshot_settings", "set_python_path", "set_python_path" }, lsp_handler2._call_order)
+      assert.are.same(
+        { "snapshot_settings", "set_python_path", "set_python_path" },
+        lsp_handler1._call_order
+      )
+      assert.are.same(
+        { "snapshot_settings", "set_python_path", "set_python_path" },
+        lsp_handler2._call_order
+      )
       current_selected:revert()
       retrieve_cache:revert()
     end)

--- a/tests/search_spec.lua
+++ b/tests/search_spec.lua
@@ -1,0 +1,206 @@
+local stub = require("luassert.stub")
+local mock_fs = require("tests.helpers.mock_fs")
+local locator_mod = require("whichpy.locator")
+local InterpreterInfo = locator_mod.InterpreterInfo
+
+local function make_sync_locator(name, paths)
+  local locator = {
+    name = name,
+    display_name = name,
+    get_env_var_strategy = function()
+      return {}
+    end,
+  }
+  locator.find = function(_)
+    return coroutine.wrap(function()
+      for _, path in ipairs(paths) do
+        coroutine.yield(InterpreterInfo:new({ locator = locator, path = path }))
+      end
+    end)
+  end
+  return locator
+end
+
+local function make_async_locator(name)
+  local locator = {
+    name = name,
+    display_name = name,
+    get_env_var_strategy = function()
+      return {}
+    end,
+  }
+  locator.find = function(_)
+    return coroutine.wrap(function()
+      coroutine.yield({ locator_name = name, wait = true })
+    end)
+  end
+  return locator
+end
+
+local function make_async_ctx(locator, paths)
+  return {
+    locator_name = locator.name,
+    co = function()
+      return coroutine.wrap(function()
+        for _, path in ipairs(paths) do
+          coroutine.yield(InterpreterInfo:new({ locator = locator, path = path }))
+        end
+      end)
+    end,
+  }
+end
+
+describe("SearchJob", function()
+  local SearchJob = require("whichpy.search")
+  local original_locators
+  local set_envs_stub
+
+  before_each(function()
+    original_locators = {}
+    for k, v in pairs(locator_mod.locators) do
+      original_locators[k] = v
+    end
+    -- Clear all locators
+    for k in pairs(locator_mod.locators) do
+      locator_mod.locators[k] = nil
+    end
+
+    SearchJob.co = nil
+    SearchJob._temp_envs = {}
+
+    set_envs_stub = stub(require("whichpy.envs"), "set_envs")
+  end)
+
+  after_each(function()
+    -- Restore original locators
+    for k in pairs(locator_mod.locators) do
+      locator_mod.locators[k] = nil
+    end
+    for k, v in pairs(original_locators) do
+      locator_mod.locators[k] = v
+    end
+
+    set_envs_stub:revert()
+    mock_fs.teardown()
+  end)
+
+  it("should collect all results from sync locators", function()
+    mock_fs.setup({
+      ["/a/bin"] = { python = "file" },
+      ["/b/bin"] = { python = "file" },
+      ["/c/bin"] = { python = "file" },
+    })
+
+    locator_mod.locators["loc1"] = make_sync_locator("loc1", { "/a/bin/python", "/b/bin/python" })
+    locator_mod.locators["loc2"] = make_sync_locator("loc2", { "/c/bin/python" })
+
+    local finished = false
+    SearchJob:update_hook(nil, function()
+      finished = true
+    end)
+    SearchJob:start()
+
+    assert.is_true(finished)
+    assert.are.equal(3, #SearchJob._temp_envs)
+    assert.spy(set_envs_stub).was.called(1)
+  end)
+
+  it("should trigger on_result for each result", function()
+    mock_fs.setup({
+      ["/a/bin"] = { python = "file" },
+      ["/b/bin"] = { python = "file" },
+    })
+
+    locator_mod.locators["loc1"] = make_sync_locator("loc1", { "/a/bin/python", "/b/bin/python" })
+
+    local result_count = 0
+    SearchJob:update_hook(function(_)
+      result_count = result_count + 1
+    end, nil)
+    SearchJob:start()
+
+    assert.are.equal(2, result_count)
+  end)
+
+  it("should call on_finish exactly once", function()
+    locator_mod.locators["loc1"] = make_sync_locator("loc1", {})
+
+    local finish_count = 0
+    SearchJob:update_hook(nil, function()
+      finish_count = finish_count + 1
+    end)
+    SearchJob:start()
+
+    assert.are.equal(1, finish_count)
+  end)
+
+  it("should handle async locator success", function()
+    mock_fs.setup({
+      ["/async/bin"] = { python = "file" },
+    })
+
+    local async_loc = make_async_locator("async1")
+    locator_mod.locators["async1"] = async_loc
+
+    local finished = false
+    SearchJob:update_hook(nil, function()
+      finished = true
+    end)
+    SearchJob:start()
+
+    assert.is_false(finished)
+
+    SearchJob:continue(make_async_ctx(async_loc, { "/async/bin/python" }))
+
+    assert.is_true(finished)
+    assert.are.equal(1, #SearchJob._temp_envs)
+  end)
+
+  it("should handle async locator error", function()
+    local async_loc = make_async_locator("async_err")
+    locator_mod.locators["async_err"] = async_loc
+
+    local notify_stub = stub(vim, "schedule")
+
+    local finished = false
+    SearchJob:update_hook(nil, function()
+      finished = true
+    end)
+    SearchJob:start()
+
+    assert.is_false(finished)
+
+    SearchJob:continue({ locator_name = "async_err", err = "command failed" })
+
+    assert.is_true(finished)
+    assert.are.equal(0, #SearchJob._temp_envs)
+
+    notify_stub:revert()
+  end)
+
+  it("should collect results from sync and async locators", function()
+    mock_fs.setup({
+      ["/sync/bin"] = { python = "file" },
+      ["/async/bin"] = { python = "file" },
+    })
+
+    locator_mod.locators["sync1"] = make_sync_locator("sync1", { "/sync/bin/python" })
+
+    local async_loc = make_async_locator("async1")
+    locator_mod.locators["async1"] = async_loc
+
+    local finished = false
+    SearchJob:update_hook(nil, function()
+      finished = true
+    end)
+    SearchJob:start()
+
+    assert.is_false(finished)
+    assert.are.equal(1, #SearchJob._temp_envs)
+
+    SearchJob:continue(make_async_ctx(async_loc, { "/async/bin/python" }))
+
+    assert.is_true(finished)
+    assert.are.equal(2, #SearchJob._temp_envs)
+  end)
+end)


### PR DESCRIPTION
I have a global env which is found on startup.  If I then (without opening a python file yet) go and cd to a directory I've previously explicitly set the env in, it wouldn't change the env to that directory as one was already set.

I think it's different having explicitly set an env vs having one picked from the cache, so I modified things to track if the env was explicitly chosen and a config option to allow automatic override when the previous setting was implicit.

For extra, I included a lualine component which uses "nvim-tree/nvim-web-devicons".

